### PR TITLE
Bump dependencies on develop to match main

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,14 +3,14 @@
   "isRoot": true,
   "tools": {
     "csharpier": {
-      "version": "1.2.5",
+      "version": "1.2.6",
       "commands": [
         "csharpier"
       ],
       "rollForward": false
     },
     "husky": {
-      "version": "0.8.0",
+      "version": "0.9.1",
       "commands": [
         "husky"
       ],

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,11 +1,11 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
+    <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.analyzers" Version="1.26.0" />
+    <PackageVersion Include="xunit.analyzers" Version="1.27.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Small PR to sync develop's dependency versions up to main (follow-up after the dual-publish landing) and to exercise the new PR pipeline end-to-end.

Touches `Directory.Packages.props` + `.config/dotnet-tools.json` (the workflow's shared paths-filter anchor), so the smoke build should run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)