### PR TITLE
Bump version to 3.5 for next prerelease cycle

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-	"version": "3.4",
+	"version": "3.5",
 	"publicReleaseRefSpec": [
 		"^refs/heads/main$"
 	],


### PR DESCRIPTION
Isolated version bump establishing the develop-leads invariant: raises `develop`'s minor from `3.4` to `3.5` so develop's NBGV prereleases sort above main's last stable `3.4.x`. Standalone version-only change per the versioning policy.