### PR TITLE
Keep jq stderr in jq_lacks (converge configure.sh)

### DIFF
--- a/repo-config/configure.sh
+++ b/repo-config/configure.sh
@@ -86,11 +86,11 @@ assert() {
 jq_has() { jq -e "$@" >/dev/null 2>&1; }
 
 # jq_lacks FILTER... - true iff the jq filter yields no truthy value (selects nothing, or only false/null).
-# `jq -e` exits 1 (last output false/null) or 4
-# (no output at all) for the "lacks" cases, 0 for a truthy match, and 2/3/5 for a real error (malformed filter
-# or input), which is propagated so the calling assert fails loudly. The `|| rc=$?` keeps jq in a list (exempt
-# from set -e) so a non-zero exit captures rc instead of aborting.
-jq_lacks() { local rc=0; jq -e "$@" >/dev/null 2>&1 || rc=$?; case "$rc" in 0) return 1 ;; 1|4) return 0 ;; *) return "$rc" ;; esac; }
+# `jq -e` exits 1 (last output false/null) or 4 (no output at all) for the "lacks" cases, 0 for a truthy
+# match, and 2/3/5 for a real error (malformed filter or input), which is propagated so the calling assert
+# fails loudly. The `|| rc=$?` keeps jq in a list (exempt from set -e) so a non-zero exit captures rc instead
+# of aborting. Only stdout is discarded - jq's stderr is kept so a real error shows its diagnostic.
+jq_lacks() { local rc=0; jq -e "$@" >/dev/null || rc=$?; case "$rc" in 0) return 1 ;; 1|4) return 0 ;; *) return "$rc" ;; esac; }
 
 check_ruleset() { # name  expected-merge-method  expect-linear(true/false)
   local name="$1" method="$2" linear="$3" id rs


### PR DESCRIPTION
Discard only stdout in `jq_lacks` (drop `2>&1`) and reflow the comment to the canonical wrapping. jq's exit 0/1/4 cases produce no stderr so normal audit runs stay silent, but a real jq error (exit 2/3/5) now prints its diagnostic instead of failing silently.

Converges `repo-config/configure.sh` byte-for-byte with the other three repos, where Copilot surfaced this. Verified: `bash -n`, shellcheck.