### PR TITLE
Reword diagram-intro sentence for clarity

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -228,7 +228,7 @@ download URL.
 ### Flow diagrams
 
 Three diagrams trace the architecture above: the pull-request gate, the self-publisher, and the bot
-automation. They are the same outcomes the section 4 contract specifies, drawn from the workflow YAML; if a diagram and
+automation. They depict the same outcomes that the section 4 contract specifies, drawn from the workflow YAML; if a diagram and
 a guarantee disagree, one of them is a defect. Triggers are blue, gates yellow, durable/published outputs
 green, and stop/skip outcomes red.
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -228,7 +228,7 @@ download URL.
 ### Flow diagrams
 
 Three diagrams trace the architecture above: the pull-request gate, the self-publisher, and the bot
-automation. They are the same outcomes section 4 contracts, drawn from the workflow YAML; if a diagram and
+automation. They are the same outcomes the section 4 contract specifies, drawn from the workflow YAML; if a diagram and
 a guarantee disagree, one of them is a defect. Triggers are blue, gates yellow, durable/published outputs
 green, and stop/skip outcomes red.
 


### PR DESCRIPTION
Fleet-wide polish: reword the diagram-section intro sentence (Copilot flagged the original as garden-path grammar on several repos) to 'the same outcomes the section 4 contract specifies', applied identically across all seven repos for convergence.

markdownlint clean, EOL preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)