### PR TITLE
Address filed configuration and doc defects

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -104,7 +104,7 @@ violate section 4.
   trigger blocks. `workflow_dispatch` delivers the string `"true"`/`"false"`, so any `if:` consuming it
   compares both forms: `${{ inputs.foo == true || inputs.foo == 'true' }}`.
 - **Reusable-workflow permissions.** Job-level `permissions:` are validated before `if:`, so even a
-  skipped job needs valid permissions declared. Grant least privilege. A callee's extra scope (e.g.
+  skipped job's declared permissions must be valid. Grant least privilege. A callee's extra scope (e.g.
   `actions: write` to delete artifacts) is granted by the caller at the `uses:` job.
 - **Allowlist `success` and `skipped` explicitly** when chaining across an optional dependency.
   `!= 'failure'` lets `cancelled` through. Use `(needs.X.result == 'success' || needs.X.result ==
@@ -453,7 +453,7 @@ applicable guarantee is not operational (section 1).
 - **D7.1 The publisher does not cancel mid-flight.** Output: the publisher's concurrency uses a
   ref-independent group with `cancel-in-progress: false`. All other entry workflows use the
   `...-${{ github.ref }}` group with `cancel-in-progress: true`, except the merge-bot (D8.1).
-- **D7.2 Skipped jobs still need valid permissions.** Output: every reusable job declares valid
+- **D7.2 Skipped jobs still need valid permissions.** Output: every reusable job runs under valid least-privilege
   `permissions:`, and a callee's extra scope is granted by the caller.
 - **D7.3 Boolean inputs both forms.** Output: boolean inputs are declared in both trigger blocks and
   compared against `true` and `'true'`.

--- a/repo-config/configure.sh
+++ b/repo-config/configure.sh
@@ -139,7 +139,7 @@ check_security() {
   # 404 when disabled; automated-security-fixes returns { "enabled": true/false }.
   assert "Dependabot vulnerability alerts enabled" gh_ok "repos/$REPO/vulnerability-alerts"
   assert "Dependabot automated security updates enabled" \
-    jq_has '.enabled == true' < <(gh api "repos/$REPO/automated-security-fixes" 2>/dev/null)
+    jq_has '.enabled == true' < <(gh api "repos/$REPO/automated-security-fixes")
 }
 
 check_secrets() {


### PR DESCRIPTION
- configure.sh: drop 2>/dev/null in check_security so gh's error surfaces (matches check_secrets).
- WORKFLOW.md D7.2/section 2: reword so it no longer claims reusable tasks *declare* permissions (they run under the caller's least-privilege grant).

Closes #359

Validation: shellcheck + actionlint + markdownlint clean; line endings preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)