### PR TITLE
Carry template upstream-drift reporting paragraph into copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -150,3 +150,5 @@ After the final push, sweep-resolve stale older threads for removed code paths.
 ## When in Doubt
 
 Read [AGENTS.md](../AGENTS.md) for this repo's conventions. For code-style rules, [`CODESTYLE.md`](../CODESTYLE.md) (its General and .NET sections) is authoritative. Don't restate any of these files' rules in commit bodies or PR descriptions - keep those focused on the change itself.
+
+**In a derived repo:** if you find a discrepancy that should be fixed in the template itself (this file or AGENTS.md is out of date, a rule is missing, something bit this repo and would bite the next), open an issue upstream in [`ptr727/ProjectTemplate`](https://github.com/ptr727/ProjectTemplate) rather than only fixing it locally - see the template's [AGENTS.md "Staying in Sync and Reporting Drift Upstream"](https://github.com/ptr727/ProjectTemplate/blob/main/AGENTS.md#staying-in-sync-and-reporting-drift-upstream).


### PR DESCRIPTION
Closes the last substantive verbatim-carry gap found while auditing this repo against ptr727/ProjectTemplate for the convergence issues #329 and #339.

## What changed
- `.github/copilot-instructions.md`: append the template's **"In a derived repo:"** paragraph (verbatim) to the "When in Doubt" section, directing contributors to open an upstream issue in `ptr727/ProjectTemplate` when a discrepancy belongs in the template rather than only fixing it locally.

## Audit result (context)
A full audit of #329 and #339 against the current template found nearly everything already converged (this repo is intentionally NuGet-only, no codegen, no Docker):
- **#329**: the Copilot review runbook in `.github/copilot-instructions.md`, the AGENTS.md "PR Review Etiquette" contract, and `.markdownlint-cli2.jsonc` (byte-identical) are all already present.
- **#339**: `.editorconfig` `[*.cs]` marked .NET-only with matching EOL rules; the AGENTS.md rule updates (comments house-rule, markdown trailing-backslash, versioning without "develop-ahead"); `CODESTYLE.md` (General + .NET, Python dropped); `retention-days: 1` on the one artifact upload. CI-storage/Docker-cache items are N/A (no Docker workflow).

The only outstanding item was this one paragraph.

Issue-closing keywords are intentionally omitted here (this PR targets `develop`); `Closes #329`/`Closes #339` will go on the `develop -> main` promotion PR so GitHub fires them on merge to the default branch.

Note: issue #348 (branch-ruleset drift) is maintainer-gated live-config and is intentionally not addressed here.