### PR TITLE
Add the global editorconfig CRLF default

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,7 @@ root = true
 # Defaults
 [*]
 charset = utf-8
+end_of_line = crlf
 indent_size = 4
 indent_style = space
 insert_final_newline = true


### PR DESCRIPTION
Adds `end_of_line = crlf` to the `.editorconfig` `[*]` block, so every file type has a defined ending (matching the fleet template) instead of the per-extension-only form. The per-type CRLF rules and the `.gitattributes` LF pins are unchanged; real files stay compliant.

Resolves the recurring line-ending drift flagged in the ProjectTemplate audit (ptr727/ProjectTemplate `reports/utilities/audit.md`). First application of the audit convergence pattern (ProjectTemplate `AUDIT.md` section 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)