### PR TITLE
Promote develop to main

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,7 @@ root = true
 # Defaults
 [*]
 charset = utf-8
+end_of_line = crlf
 indent_size = 4
 indent_style = space
 insert_final_newline = true


### PR DESCRIPTION
Promote the editorconfig global-EOL fix (CRLF default with LF exceptions) from develop to main.