### PR TITLE
Upload test coverage to Codecov

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -36,6 +36,8 @@ jobs:
   validate:
     name: Validate job
     uses: ./.github/workflows/validate-task.yml
+    # Thread CODECOV_TOKEN through so the unit-test job can upload coverage.
+    secrets: inherit
 
   # Build, version, validate, push, and release the triggering branch. Grants the write scopes
   # build-release-task needs (it declares none, so the read-only smoke caller is not forced to over-grant).

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -26,6 +26,8 @@ jobs:
     name: Validate job
     if: ${{ !github.event.deleted }}
     uses: ./.github/workflows/validate-task.yml
+    # Thread CODECOV_TOKEN through so the unit-test job can upload coverage.
+    secrets: inherit
 
   # Build and pack the library in its branch configuration to prove it ships, publishing nothing. Runs on
   # every push, so a change to build-release-task is exercised head-resolved in the PR that makes it.

--- a/.github/workflows/validate-task.yml
+++ b/.github/workflows/validate-task.yml
@@ -24,8 +24,18 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Builds with TreatWarningsAsErrors, so analyzer and code-style warnings fail here.
+      # --collect drives coverlet.collector to emit Cobertura XML into ./coverage/<guid>/.
       - name: Run unit tests step
-        run: dotnet test
+        run: dotnet test --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+      # Report-only: fail_ci_if_error is false so a Codecov hiccup or an absent token never fails the gate.
+      - name: Upload coverage to Codecov step
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          directory: ./coverage
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   # The same checks the editor runs interactively, enforced in CI from the same config files: CSharpier
   # formatting, dotnet format style (EditorConfig), markdownlint, cspell on the user-facing docs, and

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,5 +1,6 @@
 <Project>
   <ItemGroup>
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="Serilog" Version="4.3.1" />

--- a/UtilitiesTests/UtilitiesTests.csproj
+++ b/UtilitiesTests/UtilitiesTests.csproj
@@ -28,6 +28,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Utilities\Utilities.csproj" />


### PR DESCRIPTION
Collect Cobertura coverage during `dotnet test` and upload it to Codecov, best-effort (`fail_ci_if_error: false`, so a Codecov hiccup or an absent token never fails the gate).

Mirrors the proven PlexCleaner pattern:

- `validate-task.yml`: `dotnet test --collect:"XPlat Code Coverage" --results-directory ./coverage`, then a `codecov/codecov-action` upload step.
- `test-pull-request.yml` and `publish-release.yml`: pass `secrets: inherit` on the `validate-task` call so `CODECOV_TOKEN` threads through to the unit-test job.
- Reference `coverlet.collector` in `UtilitiesTests` (and `Directory.Packages.props`).

Maintainer action required: add a `CODECOV_TOKEN` secret to the repo Actions secrets for uploads to authenticate. Until then, uploads are simply skipped and CI stays green.