### PR TITLE
Remove stale PackageProjectUrl from the test project

### DIFF
--- a/UtilitiesTests/UtilitiesTests.csproj
+++ b/UtilitiesTests/UtilitiesTests.csproj
@@ -12,7 +12,6 @@
     <AssemblyName>UtilitiesTests</AssemblyName>
     <RootNamespace>ptr727.Utilities.Tests</RootNamespace>
     <NeutralLanguage>en</NeutralLanguage>
-    <PackageProjectUrl>https://dev.azure.com/pieterv/</PackageProjectUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
The `UtilitiesTests` project is `IsPackable=false` and publishes nothing, so its `PackageProjectUrl` (a stale `dev.azure.com/pieterv/` URL) is dead metadata — removed. The published library keeps its GitHub `PackageProjectUrl`.

Surfaced by a Copilot review comment on the develop→main promotion (#385).

🤖 Generated with [Claude Code](https://claude.com/claude-code)