### PR TITLE
Add mocked resilience tests exercising the Polly pipeline

### DIFF
--- a/UtilitiesTests/.editorconfig
+++ b/UtilitiesTests/.editorconfig
@@ -8,3 +8,6 @@ dotnet_diagnostic.CA1707.severity = none
 
 # CA1515: xUnit discovers only public test classes, so they cannot be internal.
 dotnet_diagnostic.CA1515.severity = none
+
+# CA2007: xUnit forbids ConfigureAwait in test methods (xUnit1030), so CA2007 cannot be satisfied in test code.
+dotnet_diagnostic.CA2007.severity = none

--- a/UtilitiesTests/HttpClientFactoryResilienceTests.cs
+++ b/UtilitiesTests/HttpClientFactoryResilienceTests.cs
@@ -1,0 +1,121 @@
+using System.Net;
+
+namespace ptr727.Utilities.Tests;
+
+public class HttpClientFactoryResilienceTests
+{
+    [Fact]
+    public async Task TransientStatus_IsRetriedThenSucceeds()
+    {
+        using StubHttpMessageHandler stub = new(
+            Status(HttpStatusCode.InternalServerError),
+            Status(HttpStatusCode.ServiceUnavailable),
+            Status(HttpStatusCode.OK)
+        );
+        using HttpClient client = CreateStubbedClient(stub, FastOptions());
+
+        using HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/"));
+
+        _ = response.StatusCode.Should().Be(HttpStatusCode.OK);
+        _ = stub.CallCount.Should().Be(3); // initial attempt + 2 retries
+    }
+
+    [Fact]
+    public async Task NonTransientStatus_IsNotRetried()
+    {
+        using StubHttpMessageHandler stub = new(Status(HttpStatusCode.NotFound));
+        using HttpClient client = CreateStubbedClient(stub, FastOptions());
+
+        using HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/"));
+
+        _ = response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        _ = stub.CallCount.Should().Be(1); // 404 is not transient
+    }
+
+    [Fact]
+    public async Task Timeout_IsRetried()
+    {
+        // A request timeout surfaces as a cancellation carrying an inner TimeoutException.
+        using StubHttpMessageHandler stub = new(
+            Throws(new TaskCanceledException("timeout", new TimeoutException()))
+        );
+        HttpClientOptions options = FastOptions();
+        options.RetryMaxAttempts = 2;
+        using HttpClient client = CreateStubbedClient(stub, options);
+
+        _ = await FluentActions
+            .Awaiting(() => client.GetAsync(new Uri("http://localhost/")))
+            .Should()
+            .ThrowAsync<TaskCanceledException>();
+        _ = stub.CallCount.Should().Be(3); // initial attempt + 2 retries
+    }
+
+    [Fact]
+    public async Task CallerCancellation_IsNotRetried()
+    {
+        // Caller-requested cancellation is not transient and must not be retried.
+        using StubHttpMessageHandler stub = new(
+            Throws(new OperationCanceledException("cancelled"))
+        );
+        using HttpClient client = CreateStubbedClient(stub, FastOptions());
+
+        _ = await FluentActions
+            .Awaiting(() => client.GetAsync(new Uri("http://localhost/")))
+            .Should()
+            .ThrowAsync<OperationCanceledException>();
+        _ = stub.CallCount.Should().Be(1); // no retry on cancellation
+    }
+
+    private static HttpClientOptions FastOptions() =>
+        new()
+        {
+            RetryBaseDelay = TimeSpan.FromMilliseconds(1),
+            RetryMaxDelay = TimeSpan.FromMilliseconds(5),
+        };
+
+    private static Func<Task<HttpResponseMessage>> Status(HttpStatusCode statusCode) =>
+        () => Task.FromResult(new HttpResponseMessage(statusCode));
+
+    private static Func<Task<HttpResponseMessage>> Throws(Exception exception) =>
+        () => Task.FromException<HttpResponseMessage>(exception);
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "Ownership of the handler chain transfers to the returned HttpClient, which the caller disposes."
+    )]
+    private static HttpClient CreateStubbedClient(
+        StubHttpMessageHandler stub,
+        HttpClientOptions options
+    )
+    {
+        DelegatingHandler resilience = HttpClientFactory.CreateResilienceHandler(options);
+
+        // Replace the factory's real network handler with the stub transport.
+        resilience.InnerHandler?.Dispose();
+        resilience.InnerHandler = stub;
+
+        return new HttpClient(resilience);
+    }
+}
+
+/// <summary>
+/// A stub HTTP transport that returns a scripted sequence of results and counts calls. The last
+/// step repeats once the sequence is exhausted, so a single step models a repeating outcome.
+/// </summary>
+internal sealed class StubHttpMessageHandler(params Func<Task<HttpResponseMessage>>[] steps)
+    : HttpMessageHandler
+{
+    private readonly Queue<Func<Task<HttpResponseMessage>>> _steps = new(steps);
+
+    internal int CallCount { get; private set; }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken
+    )
+    {
+        CallCount++;
+        return (_steps.Count > 1 ? _steps.Dequeue() : _steps.Peek())();
+    }
+}

--- a/UtilitiesTests/HttpClientFactoryResilienceTests.cs
+++ b/UtilitiesTests/HttpClientFactoryResilienceTests.cs
@@ -103,10 +103,20 @@ public class HttpClientFactoryResilienceTests
 /// A stub HTTP transport that returns a scripted sequence of results and counts calls. The last
 /// step repeats once the sequence is exhausted, so a single step models a repeating outcome.
 /// </summary>
-internal sealed class StubHttpMessageHandler(params Func<Task<HttpResponseMessage>>[] steps)
-    : HttpMessageHandler
+internal sealed class StubHttpMessageHandler : HttpMessageHandler
 {
-    private readonly Queue<Func<Task<HttpResponseMessage>>> _steps = new(steps);
+    private readonly Queue<Func<Task<HttpResponseMessage>>> _steps;
+
+    internal StubHttpMessageHandler(params Func<Task<HttpResponseMessage>>[] steps)
+    {
+        ArgumentNullException.ThrowIfNull(steps);
+        if (steps.Length == 0)
+        {
+            throw new ArgumentException("At least one step is required.", nameof(steps));
+        }
+
+        _steps = new Queue<Func<Task<HttpResponseMessage>>>(steps);
+    }
 
     internal int CallCount { get; private set; }
 


### PR DESCRIPTION
## Summary

Adds deterministic, network-free tests that actually exercise the `HttpClientFactory` resilience pipeline (previously the factory tests only constructed clients). A stub `HttpMessageHandler` is swapped in as the resilience handler's inner transport, so the real Polly retry/circuit-breaker pipeline runs against scripted outcomes offline.

Covers the transient-classification logic in `IsTransientFailure`:

- **Transient status** (500 -> 503 -> 200): retried, succeeds, handler called 3 times.
- **Non-transient status** (404): not retried, handler called once.
- **Timeout** (a cancellation carrying an inner `TimeoutException`): retried - validates that request timeouts are treated as transient.
- **Caller cancellation** (a plain `OperationCanceledException`): not retried.

These deterministically confirm the timeout-vs-cancellation behavior without relying on CI network availability.

## Notes

- Re-adds a documented test-scoped `CA2007` suppression to `UtilitiesTests/.editorconfig`: xUnit forbids `ConfigureAwait` in test methods (xUnit1030), so CA2007 is unsatisfiable in async test helpers (standard practice for test projects).
- Test-only change - no library code or public API is modified, so the published package and the sibling integrations are unaffected.

## Verification

- `dotnet build` - 0 warnings / 0 errors.
- `dotnet test` - 149 passed (+4).
- `dotnet format style --verify-no-changes` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)