### PR TITLE
Promote: resilient HttpClientFactory and AOT-safe AssemblyInfo (4.0)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Sandbox (non-AOT)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": ".NET Build",
+            "program": "${workspaceFolder}/.artifacts/bin/Sandbox/debug/Sandbox.dll",
+            "cwd": "${workspaceFolder}/Sandbox",
+            "console": "integratedTerminal",
+            "stopAtEntry": false
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -97,6 +97,27 @@
             }
         },
         {
+            "label": "Sandbox AOT Publish",
+            "type": "process",
+            "command": "dotnet",
+            "args": [
+                "publish",
+                "${workspaceFolder}/Sandbox/Sandbox.csproj",
+                "-c",
+                "Release",
+                "-r",
+                "linux-x64",
+                "-p:PublishAot=true"
+            ],
+            "problemMatcher": [
+                "$msCompile"
+            ],
+            "presentation": {
+                "showReuseMessage": false,
+                "clear": false
+            }
+        },
+        {
             "label": "Husky.Net Run",
             "type": "process",
             "command": "dotnet",

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,7 @@
   <ItemGroup>
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,14 +4,19 @@ Some useful and not so useful C# .NET utility classes.
 
 ## Release History
 
-- v3.7:
-  - Renamed the NuGet package and root namespace from `InsaneGenius.Utilities` to `ptr727.Utilities` (a breaking change), aligning with the `ptr727.*` package naming used by the sibling `LanguageTags` project; consumers must update their package reference and change `using InsaneGenius.Utilities;` directives to `using ptr727.Utilities;`. The assembly is now named `Utilities`.
-  - Replaced the Serilog-coupled logging model with the backend-agnostic `Microsoft.Extensions.Logging` abstraction, matching the sibling `LanguageTags` project.
+- v4.0:
+  - Added `HttpClientFactory`, a reusable resilient HTTP client factory built on `Microsoft.Extensions.Http.Resilience` (Polly) with retry, circuit breaker, and connection pooling, tunable through the new `HttpClientOptions`; it exposes a shared singleton client, caller-owned clients, and the resilience handler for callers that build their own client with a custom base address or headers.
+  - Added `AssemblyInfo`, an AOT safe assembly and application identity helper whose `For<T>()` substitutes for `Assembly.GetExecutingAssembly()` (unreliable under Native AOT), and which supplies the consuming application name, version, and a default User-Agent.
+  - Reworked `Download` to build its `HttpClient` through `HttpClientFactory`, so downloads now flow through the shared retry and circuit-breaker pipeline; the `TimeoutSeconds` property and all method signatures are unchanged.
+  - Changed public members that exposed `List<T>` to safe collection types (a breaking API change): `FileEx.EnumerateDirectories` / `EnumerateDirectory` now return `Collection<T>` out parameters and accept `IEnumerable<string>`, and `StringHistory.StringList` is now a `ReadOnlyCollection<string>`.
+  - Gated the library's reference AOT verification behind an explicit `PublishAot` opt-in, and turned the `Sandbox` project into a Native AOT smoke test (published and run as AOT) that proves the resilience pipeline and assembly-identity resolution work under Native AOT.
+  - Renamed the NuGet package and root namespace from `InsaneGenius.Utilities` to `ptr727.Utilities` (a breaking change); consumers must update their package reference and change `using InsaneGenius.Utilities;` directives to `using ptr727.Utilities;`. The assembly is now named `Utilities`.
+  - Replaced the Serilog-coupled logging model with the backend-agnostic `Microsoft.Extensions.Logging` abstraction.
   - Removed the global Serilog `LogOptions.Logger` property (a breaking API change) in favor of a thread-safe, injectable `ILoggerFactory` configured via `LogOptions.SetFactory(...)` / `TrySetFactory(...)`; the library now depends only on `Microsoft.Extensions.Logging.Abstractions`.
   - Reworked `FileEx` and `Download` to resolve per-class cached loggers through `LogOptions.CreateLogger(...)` and to emit source-generated `[LoggerMessage]` messages, keeping the build clean under `AnalysisMode=All` and `TreatWarningsAsErrors`.
   - Moved the `LogAndHandle` / `LogAndPropagate` helpers onto `Microsoft.Extensions.Logging.ILogger` as internal extensions (exposed to tests via `InternalsVisibleTo`).
   - Renamed the public `Extensions` class to `CompressExtensions` (a breaking API change for direct references; instance-style extension calls such as `value.Compress()` are unaffected), resolving the naming clash with the `Microsoft.Extensions` namespace.
-  - Updated the `Sandbox` example to configure a Serilog console logger and inject it through a `SerilogLoggerFactory`, borrowing the pattern from `LanguageTagsCreate`.
+  - Updated the `Sandbox` example to configure a Serilog console logger and inject it through a `SerilogLoggerFactory`.
   - Dropped the library's Serilog dependency and its `IL3058` AOT warning suppression.
 - v3.6:
   - Reworked the CI/CD pipeline to the branch-scoped self-publishing model: `main` publishes stable releases and `develop` publishes prereleases, each branch publishing itself when a shipped input changes.

--- a/README.md
+++ b/README.md
@@ -21,15 +21,17 @@ Some useful and not so useful C# .NET utility classes.
 
 ### Release Notes
 
-**Version: 3.7**:
+**Version: 4.0**:
+
+**⚠️ Breaking Changes**:
+
+- Renamed the NuGet package and namespace from `InsaneGenius.Utilities` to `ptr727.Utilities`.
+- Replaced Serilog with an injectable `Microsoft.Extensions.Logging` logging model.
+- Replaced `List<T>` in public methods with `Collection<T>` and `ReadOnlyCollection<T>`.
 
 **Summary**:
 
-- Renamed the NuGet package and namespace from `InsaneGenius.Utilities` to `ptr727.Utilities` (breaking).
-  - Update your package reference to `ptr727.Utilities` and change `using InsaneGenius.Utilities;` to `using ptr727.Utilities;`.
-- Adopted an injectable `Microsoft.Extensions.Logging` logging model (breaking).
-  - Configure logging with `LogOptions.SetFactory(ILoggerFactory)` instead of the removed Serilog-typed `LogOptions.Logger` property.
-  - The library now depends on `Microsoft.Extensions.Logging.Abstractions` and is backend-agnostic; the `Sandbox` shows Serilog console wiring.
+- Added `HttpClientFactory`, a reusable resilient HTTP client factory (Polly retry and circuit breaker) with an AOT safe `AssemblyInfo` identity helper and a tunable `HttpClientOptions`.
 
 See [Release History](./HISTORY.md) for complete release notes and older versions.
 

--- a/Sandbox/AssemblyIdentitySample.cs
+++ b/Sandbox/AssemblyIdentitySample.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+
+namespace ptr727.Utilities.Sandbox;
+
+/// <summary>
+/// Validates AOT-safe assembly and application identity resolution. Resolution must be
+/// identical whether the Sandbox runs as a regular managed build or a Native AOT binary; this
+/// is the definitive test that the GetExecutingAssembly substitute works under AOT.
+/// </summary>
+internal static class AssemblyIdentitySample
+{
+    /// <summary>
+    /// Runs the sample.
+    /// </summary>
+    /// <returns>True if the application identity resolved, false otherwise.</returns>
+    internal static bool Run()
+    {
+        Assembly markerAssembly = AssemblyInfo.For<Program>();
+        Log.Logger.Information(
+            "Identity: MarkerAssembly={MarkerAssembly}, AppName={AppName}, AppVersion={AppVersion}, UserAgent={UserAgent}",
+            markerAssembly.GetName().Name,
+            AssemblyInfo.AppName,
+            AssemblyInfo.AppVersion,
+            AssemblyInfo.DefaultUserAgent.ToString()
+        );
+
+        // Hard runtime check: Debug.Assert is compiled out of an AOT Release build, so fail
+        // explicitly if the consuming-application identity did not resolve.
+        if (string.IsNullOrEmpty(AssemblyInfo.AppName) || AssemblyInfo.AppName == "Unknown")
+        {
+            Log.Logger.Error(
+                "Application identity did not resolve: AppName={AppName}",
+                AssemblyInfo.AppName
+            );
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Sandbox/HttpClientSample.cs
+++ b/Sandbox/HttpClientSample.cs
@@ -1,0 +1,39 @@
+namespace ptr727.Utilities.Sandbox;
+
+/// <summary>
+/// Exercises the resilient <see cref="HttpClientFactory"/> pipeline under the current runtime
+/// (AOT or managed). A request to a closed local port forces a deterministic transient failure
+/// that drives the retry path offline; the emitted retry log lines are the runtime proof that
+/// the Polly pipeline executed.
+/// </summary>
+internal static class HttpClientSample
+{
+    /// <summary>
+    /// Runs the sample.
+    /// </summary>
+    /// <returns>A task that completes when the sample finishes.</returns>
+    internal static async Task RunAsync()
+    {
+        HttpClientOptions probe = new()
+        {
+            Timeout = TimeSpan.FromSeconds(5),
+            RetryBaseDelay = TimeSpan.FromMilliseconds(10),
+            RetryMaxDelay = TimeSpan.FromMilliseconds(50),
+        };
+        using HttpClient client = HttpClientFactory.CreateClient(probe);
+        try
+        {
+            using HttpResponseMessage response = await client
+                .GetAsync(new Uri("http://127.0.0.1:1/"))
+                .ConfigureAwait(false);
+            Log.Logger.Information("Unexpected success: {StatusCode}", response.StatusCode);
+        }
+        catch (HttpRequestException exception)
+        {
+            Log.Logger.Information(
+                "Resilience pipeline exercised, expected failure: {Message}",
+                exception.Message
+            );
+        }
+    }
+}

--- a/Sandbox/Program.cs
+++ b/Sandbox/Program.cs
@@ -1,23 +1,33 @@
-using System.Diagnostics;
-using System.Reflection;
-using ptr727.Utilities;
-using ptr727.Utilities.Sandbox;
+namespace ptr727.Utilities.Sandbox;
 
-// Configure logging: build a Serilog console logger and inject it into the library.
-Log.Logger = LoggerFactory.Create();
-LogOptions.SetFactory(LoggerFactory.CreateLoggerFactory());
+/// <summary>
+/// Sandbox entry point. Each sample class exercises a slice of the library and is invoked
+/// from <see cref="Main"/>; comment out a call to skip that sample for a given run.
+/// </summary>
+internal sealed class Program
+{
+    private Program() { }
 
-try
-{
-    // Get the assembly directory
-    Assembly? entryAssembly = Assembly.GetEntryAssembly();
-    Debug.Assert(entryAssembly != null);
-    string? assemblyDirectory = Path.GetDirectoryName(AppContext.BaseDirectory);
-    Debug.Assert(assemblyDirectory != null);
-    string projectDirectory = Path.GetFullPath(Path.Combine(assemblyDirectory, "../../../../"));
-    Log.Logger.Information("Project directory: {ProjectDirectory}", projectDirectory);
-}
-finally
-{
-    Log.CloseAndFlush();
+    private static async Task<int> Main()
+    {
+        // Configure logging: build a Serilog console logger and inject it into the library.
+        Log.Logger = LoggerFactory.Create();
+        LogOptions.SetFactory(LoggerFactory.CreateLoggerFactory());
+
+        try
+        {
+            if (!AssemblyIdentitySample.Run())
+            {
+                return 1;
+            }
+
+            await HttpClientSample.RunAsync().ConfigureAwait(false);
+
+            return 0;
+        }
+        finally
+        {
+            await Log.CloseAndFlushAsync().ConfigureAwait(false);
+        }
+    }
 }

--- a/Utilities/.editorconfig
+++ b/Utilities/.editorconfig
@@ -3,19 +3,5 @@ root = false
 # C# files
 [*.cs]
 
-# Allow Ex
+# CA1711: Allow Ex suffix
 dotnet_diagnostic.CA1711.severity = none
-
-# Library-scoped analyzer exceptions. Each is a deliberate, documented decision
-# for this published library, not a brownfield blanket-relax (see CODESTYLE.md
-# "Analyzer Diagnostics and Suppressions"). Localized single-symbol exceptions
-# (CA1024, CA1034, CA1054, CA5394) are suppressed with [SuppressMessage]
-# attributes at the specific symbol instead of here.
-# CA1002: the published ptr727.Utilities surface intentionally exposes
-#   List<T> (FileEx.EnumerateDirectory, StringHistory.StringList); changing to
-#   Collection<T> is a breaking API change.
-dotnet_diagnostic.CA1002.severity = suggestion
-# CA2007: await using / await foreach disposal sites; the awaited async calls
-#   already use ConfigureAwait(false) and a ConfiguredAsyncDisposable rewrite
-#   hurts readability.
-dotnet_diagnostic.CA2007.severity = suggestion

--- a/Utilities/AssemblyInfo.cs
+++ b/Utilities/AssemblyInfo.cs
@@ -1,0 +1,78 @@
+using System.Net.Http.Headers;
+using System.Reflection;
+
+namespace ptr727.Utilities;
+
+/// <summary>
+/// Provides AOT and trim safe access to assembly and consuming-application identity.
+/// </summary>
+/// <remarks>
+/// Native AOT does not support <see cref="Assembly.GetExecutingAssembly"/> reliably
+/// (see https://github.com/dotnet/runtime/issues/94200). Use <see cref="For{T}"/> as the
+/// AOT safe substitute, passing a marker type from the assembly of interest. The
+/// application identity members make no assumptions about the hosting environment and
+/// fall back gracefully when the managed entry assembly is unavailable.
+/// </remarks>
+public static class AssemblyInfo
+{
+    /// <summary>
+    /// Gets the assembly that defines the type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">A marker type from the assembly of interest.</typeparam>
+    /// <returns>The assembly that defines <typeparamref name="T"/>.</returns>
+    /// <remarks>
+    /// This is the AOT safe replacement for <see cref="Assembly.GetExecutingAssembly"/>:
+    /// <c>typeof(T).Assembly</c> resolves at compile time with no stack walk or reflection.
+    /// </remarks>
+    public static Assembly For<T>() => typeof(T).Assembly;
+
+    /// <summary>
+    /// Gets the name of the consuming application (the entry assembly, never this library).
+    /// </summary>
+    /// <remarks>
+    /// Assembly to file metadata is unreliable under Native AOT, so the managed entry
+    /// assembly name is tried first, then the OS process executable name, then a generic value.
+    /// </remarks>
+    public static string AppName
+    {
+        get
+        {
+            string? processPath = Environment.ProcessPath;
+            string? processName = string.IsNullOrEmpty(processPath)
+                ? null
+                : Path.GetFileNameWithoutExtension(processPath);
+            return Assembly.GetEntryAssembly()?.GetName().Name ?? processName ?? "Unknown";
+        }
+    }
+
+    /// <summary>
+    /// Gets the version of the consuming application (the entry assembly), or a fallback value.
+    /// </summary>
+    /// <remarks>
+    /// Uses the AOT safe <see cref="AssemblyName.Version"/> rather than reflecting over
+    /// informational-version attributes, which the trimmer or AOT compiler may strip.
+    /// </remarks>
+    public static string AppVersion =>
+        Assembly.GetEntryAssembly()?.GetName().Version?.ToString() ?? "1.0.0";
+
+    /// <summary>
+    /// Gets a User-Agent header value identifying the consuming application.
+    /// </summary>
+    /// <remarks>
+    /// The derived name may not be a valid HTTP token (for example a process name with spaces),
+    /// so the value falls back to a guaranteed-valid token when parsing fails.
+    /// </remarks>
+    public static ProductInfoHeaderValue DefaultUserAgent
+    {
+        get
+        {
+            string appVersion = AppVersion;
+            return ProductInfoHeaderValue.TryParse(
+                $"{AppName}/{appVersion}",
+                out ProductInfoHeaderValue? userAgent
+            )
+                ? userAgent
+                : new ProductInfoHeaderValue("Unknown", appVersion);
+        }
+    }
+}

--- a/Utilities/Download.cs
+++ b/Utilities/Download.cs
@@ -1,6 +1,3 @@
-using System.Net.Http.Headers;
-using System.Reflection;
-
 namespace ptr727.Utilities;
 
 /// <summary>
@@ -8,7 +5,11 @@ namespace ptr727.Utilities;
 /// </summary>
 public static class Download
 {
-    private static readonly Lazy<HttpClient> s_httpClient = new(CreateHttpClient);
+    private static readonly Lazy<HttpClient> s_httpClient = new(() =>
+        HttpClientFactory.CreateClient(
+            new HttpClientOptions { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) }
+        )
+    );
     private static readonly Lazy<ILogger> s_logger = new(() =>
         LogOptions.CreateLogger(typeof(Download).FullName!)
     );
@@ -131,11 +132,19 @@ public static class Download
 
         try
         {
-            await using Stream httpStream = await GetHttpClient()
+            Stream httpStream = await GetHttpClient()
                 .GetStreamAsync(uri, cancellationToken)
                 .ConfigureAwait(false);
-            await using FileStream fileStream = File.OpenWrite(fileName);
-            await httpStream.CopyToAsync(fileStream, cancellationToken).ConfigureAwait(false);
+            await using (httpStream.ConfigureAwait(false))
+            {
+                FileStream fileStream = File.OpenWrite(fileName);
+                await using (fileStream.ConfigureAwait(false))
+                {
+                    await httpStream
+                        .CopyToAsync(fileStream, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+            }
         }
         catch (Exception e) when (Log.LogAndHandle(e))
         {
@@ -236,37 +245,5 @@ public static class Download
         }
 
         return uriBuilder.Uri;
-    }
-
-    private static HttpClient CreateHttpClient()
-    {
-        HttpClient client = new() { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) };
-
-        // Identify the consuming application (the caller), never this library. Assembly-to-file
-        // metadata is unreliable under NativeAOT, so try the managed entry assembly name, then
-        // the OS-level process executable name, then a generic value.
-        Assembly? entryAssembly = Assembly.GetEntryAssembly();
-        string? processPath = Environment.ProcessPath;
-        string? processName = string.IsNullOrEmpty(processPath)
-            ? null
-            : Path.GetFileNameWithoutExtension(processPath);
-        string productName = entryAssembly?.GetName().Name ?? processName ?? "Unknown";
-        string productVersion = entryAssembly?.GetName().Version?.ToString() ?? "1.0.0";
-
-        // The derived name may not be a valid HTTP token (e.g. a process name with spaces);
-        // fall back to a guaranteed-valid token so a User-Agent is always set.
-        if (
-            !ProductInfoHeaderValue.TryParse(
-                $"{productName}/{productVersion}",
-                out ProductInfoHeaderValue? userAgent
-            )
-        )
-        {
-            userAgent = new ProductInfoHeaderValue("Unknown", productVersion);
-        }
-
-        client.DefaultRequestHeaders.UserAgent.Add(userAgent);
-
-        return client;
     }
 }

--- a/Utilities/Extensions.cs
+++ b/Utilities/Extensions.cs
@@ -173,4 +173,31 @@ internal static partial class LogExtensions
         int optionsRetryCount,
         string name
     );
+
+    [LoggerMessage(
+        Message = "HTTP retry attempt {Attempt} after {DelayMs}ms : {Outcome}",
+        Level = LogLevel.Warning
+    )]
+    internal static partial void LogHttpRetry(
+        this ILogger logger,
+        int attempt,
+        double delayMs,
+        string outcome
+    );
+
+    [LoggerMessage(
+        Message = "Circuit breaker opened for {DurationSeconds}s : {Outcome}",
+        Level = LogLevel.Warning
+    )]
+    internal static partial void LogCircuitOpened(
+        this ILogger logger,
+        double durationSeconds,
+        string outcome
+    );
+
+    [LoggerMessage(Message = "Circuit breaker closed", Level = LogLevel.Information)]
+    internal static partial void LogCircuitClosed(this ILogger logger);
+
+    [LoggerMessage(Message = "Circuit breaker half-opened", Level = LogLevel.Debug)]
+    internal static partial void LogCircuitHalfOpened(this ILogger logger);
 }

--- a/Utilities/FileEx.cs
+++ b/Utilities/FileEx.cs
@@ -761,12 +761,15 @@ public static class FileEx
             try
             {
                 FileInfo fileInfo = new(fileName);
-                await using FileStream stream = fileInfo.Open(
+                FileStream stream = fileInfo.Open(
                     FileMode.Open,
                     FileAccess.Read,
                     FileShare.ReadWrite
                 );
-                result = true;
+                await using (stream.ConfigureAwait(false))
+                {
+                    result = true;
+                }
                 break;
             }
             catch (IOException e) when (Log.LogAndHandle(e))
@@ -966,15 +969,15 @@ public static class FileEx
     /// <returns>True if successful, false otherwise.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="sourceList"/> is null.</exception>
     public static bool EnumerateDirectories(
-        List<string> sourceList,
-        out List<FileInfo> fileList,
-        out List<DirectoryInfo> directoryList
+        IEnumerable<string> sourceList,
+        out Collection<FileInfo> fileList,
+        out Collection<DirectoryInfo> directoryList
     )
     {
         ArgumentNullException.ThrowIfNull(sourceList);
 
-        directoryList = [];
-        fileList = [];
+        List<DirectoryInfo> directories = [];
+        List<FileInfo> files = [];
 
         try
         {
@@ -983,26 +986,30 @@ public static class FileEx
             {
                 // Add this folder to the directory list
                 DirectoryInfo dirInfo = new(folder);
-                directoryList.Add(dirInfo);
+                directories.Add(dirInfo);
 
                 // Recursively add all child folders
-                directoryList.AddRange(
+                directories.AddRange(
                     dirInfo.EnumerateDirectories("*", SearchOption.AllDirectories)
                 );
             }
 
             // Add all files from all the directories to the file list
-            foreach (DirectoryInfo dirInfo in directoryList)
+            foreach (DirectoryInfo dirInfo in directories)
             {
                 // Add all files in this folder
-                fileList.AddRange(dirInfo.EnumerateFiles("*.*", SearchOption.TopDirectoryOnly));
+                files.AddRange(dirInfo.EnumerateFiles("*.*", SearchOption.TopDirectoryOnly));
             }
         }
         catch (Exception e) when (Log.LogAndHandle(e))
         {
+            fileList = [];
+            directoryList = [];
             return false;
         }
 
+        fileList = new Collection<FileInfo>(files);
+        directoryList = new Collection<DirectoryInfo>(directories);
         return true;
     }
 
@@ -1015,13 +1022,9 @@ public static class FileEx
     /// <returns>True if successful, false otherwise.</returns>
     public static bool EnumerateDirectory(
         string directory,
-        out List<FileInfo> fileList,
-        out List<DirectoryInfo> directoryList
-    )
-    {
-        List<string> sourceList = [directory];
-        return EnumerateDirectories(sourceList, out fileList, out directoryList);
-    }
+        out Collection<FileInfo> fileList,
+        out Collection<DirectoryInfo> directoryList
+    ) => EnumerateDirectories([directory], out fileList, out directoryList);
 
     /// <summary>
     /// Resets directory permissions to grant everyone full control (Windows only).
@@ -1166,29 +1169,34 @@ public static class FileEx
     {
         try
         {
-            await using FileStream stream = File.Open(
+            FileStream stream = File.Open(
                 name,
                 FileMode.Create,
                 FileAccess.ReadWrite,
                 FileShare.ReadWrite
             );
-
-            stream.SetLength(size);
-            _ = stream.Seek(0, SeekOrigin.Begin);
-
-            const int bufferSize = 2 * Format.MiB;
-            byte[] buffer = new byte[bufferSize];
-            Random rand = new();
-
-            long remaining = size;
-            while (remaining > 0)
+            await using (stream.ConfigureAwait(false))
             {
-                rand.NextBytes(buffer);
-                long writeSize = Math.Min(remaining, Convert.ToInt64(buffer.Length));
-                await stream
-                    .WriteAsync(buffer.AsMemory(0, Convert.ToInt32(writeSize)), cancellationToken)
-                    .ConfigureAwait(false);
-                remaining -= writeSize;
+                stream.SetLength(size);
+                _ = stream.Seek(0, SeekOrigin.Begin);
+
+                const int bufferSize = 2 * Format.MiB;
+                byte[] buffer = new byte[bufferSize];
+                Random rand = new();
+
+                long remaining = size;
+                while (remaining > 0)
+                {
+                    rand.NextBytes(buffer);
+                    long writeSize = Math.Min(remaining, Convert.ToInt64(buffer.Length));
+                    await stream
+                        .WriteAsync(
+                            buffer.AsMemory(0, Convert.ToInt32(writeSize)),
+                            cancellationToken
+                        )
+                        .ConfigureAwait(false);
+                    remaining -= writeSize;
+                }
             }
         }
         catch (Exception e) when (Log.LogAndHandle(e))
@@ -1238,14 +1246,16 @@ public static class FileEx
     {
         try
         {
-            await using FileStream stream = File.Open(
+            FileStream stream = File.Open(
                 name,
                 FileMode.OpenOrCreate,
                 FileAccess.ReadWrite,
                 FileShare.ReadWrite
             );
-
-            stream.SetLength(size);
+            await using (stream.ConfigureAwait(false))
+            {
+                stream.SetLength(size);
+            }
         }
         catch (Exception e) when (Log.LogAndHandle(e))
         {

--- a/Utilities/FileEx.cs
+++ b/Utilities/FileEx.cs
@@ -963,9 +963,9 @@ public static class FileEx
     /// <summary>
     /// Enumerates all files and directories in the specified source directories.
     /// </summary>
-    /// <param name="sourceList">The list of source directories to enumerate.</param>
-    /// <param name="fileList">Output list of all files found.</param>
-    /// <param name="directoryList">Output list of all directories found (includes source directories).</param>
+    /// <param name="sourceList">The source directories to enumerate.</param>
+    /// <param name="fileList">Output collection of all files found.</param>
+    /// <param name="directoryList">Output collection of all directories found (includes source directories).</param>
     /// <returns>True if successful, false otherwise.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="sourceList"/> is null.</exception>
     public static bool EnumerateDirectories(
@@ -981,7 +981,7 @@ public static class FileEx
 
         try
         {
-            // Add all directories and files from the list of folders
+            // Add all directories and files from the source folders
             foreach (string folder in sourceList)
             {
                 // Add this folder to the directory list
@@ -1017,8 +1017,8 @@ public static class FileEx
     /// Enumerates all files and directories in the specified directory.
     /// </summary>
     /// <param name="directory">The directory to enumerate.</param>
-    /// <param name="fileList">Output list of all files found.</param>
-    /// <param name="directoryList">Output list of all directories found (includes the specified directory).</param>
+    /// <param name="fileList">Output collection of all files found.</param>
+    /// <param name="directoryList">Output collection of all directories found (includes the specified directory).</param>
     /// <returns>True if successful, false otherwise.</returns>
     public static bool EnumerateDirectory(
         string directory,

--- a/Utilities/GlobalUsings.cs
+++ b/Utilities/GlobalUsings.cs
@@ -1,1 +1,2 @@
+global using System.Collections.ObjectModel;
 global using Microsoft.Extensions.Logging;

--- a/Utilities/HttpClientFactory.cs
+++ b/Utilities/HttpClientFactory.cs
@@ -163,19 +163,26 @@ public static class HttpClientFactory
         if (outcome.Exception is null)
         {
             return outcome.Result is not null
-                && (int)outcome.Result.StatusCode is 408 or 429 or >= 500;
+                && IsTransientStatusCode((int)outcome.Result.StatusCode);
         }
 
-        // Retry only known-transient failures: a timeout (a cancellation with an inner
-        // TimeoutException) or a network/IO error. Caller cancellation, an open circuit, and any
-        // other exception (including programming errors) are not retried.
+        // Retry known-transient failures: a request timeout (a cancellation with an inner
+        // TimeoutException), a network or IO error (an HttpRequestException with no status, or an
+        // IOException), or an HttpRequestException whose own status code is transient (408, 429,
+        // >= 500). Caller cancellation, an open circuit, a 4xx status, and any other exception
+        // (including programming errors) are not retried.
         return outcome.Exception switch
         {
             OperationCanceledException canceled => canceled.InnerException is TimeoutException,
-            HttpRequestException or IOException => true,
+            HttpRequestException { StatusCode: null } or IOException => true,
+            HttpRequestException { StatusCode: { } statusCode } => IsTransientStatusCode(
+                (int)statusCode
+            ),
             _ => false,
         };
     }
+
+    private static bool IsTransientStatusCode(int statusCode) => statusCode is 408 or 429 or >= 500;
 
     private static string FormatOutcome(Outcome<HttpResponseMessage> outcome) =>
         outcome.Exception?.Message ?? outcome.Result?.StatusCode.ToString() ?? "unknown";

--- a/Utilities/HttpClientFactory.cs
+++ b/Utilities/HttpClientFactory.cs
@@ -180,12 +180,14 @@ public static class HttpClientFactory
                 && (int)outcome.Result.StatusCode is 408 or 429 or >= 500;
         }
 
-        // Retry timeouts (cancellation with an inner TimeoutException), not caller cancellation or an open circuit.
+        // Retry only known-transient failures: a timeout (a cancellation with an inner
+        // TimeoutException) or a network/IO error. Caller cancellation, an open circuit, and any
+        // other exception (including programming errors) are not retried.
         return outcome.Exception switch
         {
             OperationCanceledException canceled => canceled.InnerException is TimeoutException,
-            BrokenCircuitException => false,
-            _ => true,
+            HttpRequestException or IOException => true,
+            _ => false,
         };
     }
 

--- a/Utilities/HttpClientFactory.cs
+++ b/Utilities/HttpClientFactory.cs
@@ -1,4 +1,3 @@
-using System.Net.Http.Headers;
 using Microsoft.Extensions.Http.Resilience;
 using Polly;
 using Polly.CircuitBreaker;
@@ -74,19 +73,6 @@ public static class HttpClientFactory
         );
 
         return client;
-    }
-
-    /// <summary>
-    /// Creates a new caller-owned <see cref="HttpClient"/> with the specified User-Agent and default options.
-    /// </summary>
-    /// <param name="userAgent">The User-Agent header value to use.</param>
-    /// <returns>A configured HttpClient. The caller owns and should store and reuse the instance.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="userAgent"/> is null.</exception>
-    public static HttpClient CreateClient(ProductInfoHeaderValue userAgent)
-    {
-        ArgumentNullException.ThrowIfNull(userAgent);
-
-        return CreateClient(new HttpClientOptions { UserAgent = userAgent });
     }
 
     /// <summary>

--- a/Utilities/HttpClientFactory.cs
+++ b/Utilities/HttpClientFactory.cs
@@ -1,0 +1,194 @@
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Http.Resilience;
+using Polly;
+using Polly.CircuitBreaker;
+using Polly.Retry;
+
+namespace ptr727.Utilities;
+
+/// <summary>
+/// Creates resilient <see cref="HttpClient"/> instances with retry and circuit-breaker
+/// policies, connection pooling, and an AOT safe default User-Agent.
+/// </summary>
+/// <remarks>
+/// Use <see cref="GetClient"/> for a shared singleton, <see cref="CreateClient(HttpClientOptions)"/>
+/// to build a caller-owned client from tuned options, or <see cref="CreateResilienceHandler"/> to
+/// obtain the resilience handler and build a client with a custom base address or headers.
+/// </remarks>
+public static class HttpClientFactory
+{
+    private static readonly Lazy<ILogger> s_logger = new(() =>
+        LogOptions.CreateLogger(typeof(HttpClientFactory).FullName!)
+    );
+
+    private static ILogger Log => s_logger.Value;
+
+    private static readonly HttpClientOptions s_defaultOptions = new();
+
+    private static readonly Lazy<HttpClient> s_httpClient = new(() =>
+        CreateClient(s_defaultOptions)
+    );
+
+    /// <summary>
+    /// Gets the shared, lazily-initialized <see cref="HttpClient"/> configured with default options.
+    /// </summary>
+    /// <returns>The shared HttpClient instance.</returns>
+    /// <remarks>
+    /// All callers share this client, its connection pool, and its circuit-breaker state. Do not
+    /// dispose it; it lives for the process lifetime. Use <see cref="CreateClient(HttpClientOptions)"/>
+    /// for a caller-owned instance.
+    /// </remarks>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Design",
+        "CA1024:Use properties where appropriate",
+        Justification = "Exposed as a method so callers see they receive the shared, lazily-initialized HttpClient rather than a lightweight property value."
+    )]
+    public static HttpClient GetClient() => s_httpClient.Value;
+
+    /// <summary>
+    /// Creates a new caller-owned <see cref="HttpClient"/> from the specified options.
+    /// </summary>
+    /// <param name="options">The options to configure the client. When null, defaults are used.</param>
+    /// <returns>A configured HttpClient. The caller owns and should store and reuse the instance.</returns>
+    /// <remarks>
+    /// Each client gets an independent resilience handler and circuit-breaker state. Disposing the
+    /// client disposes the whole handler chain.
+    /// </remarks>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "HttpClient takes ownership of the handler and disposes it when the client is disposed."
+    )]
+    public static HttpClient CreateClient(HttpClientOptions? options = null)
+    {
+        options ??= s_defaultOptions;
+
+        HttpClient client = new(CreateResilienceHandler(options)) { Timeout = options.Timeout };
+        if (options.BaseAddress is not null)
+        {
+            client.BaseAddress = options.BaseAddress;
+        }
+
+        client.DefaultRequestHeaders.UserAgent.Add(
+            options.UserAgent ?? AssemblyInfo.DefaultUserAgent
+        );
+
+        return client;
+    }
+
+    /// <summary>
+    /// Creates a new caller-owned <see cref="HttpClient"/> with the specified User-Agent and default options.
+    /// </summary>
+    /// <param name="userAgent">The User-Agent header value to use.</param>
+    /// <returns>A configured HttpClient. The caller owns and should store and reuse the instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="userAgent"/> is null.</exception>
+    public static HttpClient CreateClient(ProductInfoHeaderValue userAgent)
+    {
+        ArgumentNullException.ThrowIfNull(userAgent);
+
+        return CreateClient(new HttpClientOptions { UserAgent = userAgent });
+    }
+
+    /// <summary>
+    /// Creates the resilience handler (retry, circuit breaker, connection pooling) for callers
+    /// who build their own <see cref="HttpClient"/>.
+    /// </summary>
+    /// <param name="options">The options to configure the handler. When null, defaults are used.</param>
+    /// <returns>
+    /// The resilience handler. Ownership transfers to the <see cref="HttpClient"/> it is passed to,
+    /// which disposes the handler chain when the client is disposed.
+    /// </returns>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "The returned handler owns the inner SocketsHttpHandler; the consuming HttpClient disposes the chain."
+    )]
+    public static DelegatingHandler CreateResilienceHandler(HttpClientOptions? options = null)
+    {
+        options ??= s_defaultOptions;
+
+        ResiliencePipeline<HttpResponseMessage> pipeline =
+            new ResiliencePipelineBuilder<HttpResponseMessage>()
+                .AddRetry(
+                    new RetryStrategyOptions<HttpResponseMessage>
+                    {
+                        MaxRetryAttempts = options.RetryMaxAttempts,
+                        BackoffType = DelayBackoffType.Exponential,
+                        UseJitter = true,
+                        Delay = options.RetryBaseDelay,
+                        MaxDelay = options.RetryMaxDelay,
+                        ShouldHandle = args =>
+                            ValueTask.FromResult(IsTransientFailure(args.Outcome)),
+                        OnRetry = args =>
+                        {
+                            Log.LogHttpRetry(
+                                args.AttemptNumber,
+                                args.RetryDelay.TotalMilliseconds,
+                                FormatOutcome(args.Outcome)
+                            );
+                            return ValueTask.CompletedTask;
+                        },
+                    }
+                )
+                .AddCircuitBreaker(
+                    new CircuitBreakerStrategyOptions<HttpResponseMessage>
+                    {
+                        FailureRatio = options.CircuitBreakerFailureRatio,
+                        MinimumThroughput = options.CircuitBreakerMinimumThroughput,
+                        SamplingDuration = options.CircuitBreakerSamplingDuration,
+                        BreakDuration = options.CircuitBreakerBreakDuration,
+                        ShouldHandle = args =>
+                            ValueTask.FromResult(IsTransientFailure(args.Outcome)),
+                        OnOpened = args =>
+                        {
+                            Log.LogCircuitOpened(
+                                args.BreakDuration.TotalSeconds,
+                                FormatOutcome(args.Outcome)
+                            );
+                            return ValueTask.CompletedTask;
+                        },
+                        OnClosed = _ =>
+                        {
+                            Log.LogCircuitClosed();
+                            return ValueTask.CompletedTask;
+                        },
+                        OnHalfOpened = _ =>
+                        {
+                            Log.LogCircuitHalfOpened();
+                            return ValueTask.CompletedTask;
+                        },
+                    }
+                )
+                .Build();
+
+        return new ResilienceHandler(pipeline)
+        {
+            InnerHandler = new SocketsHttpHandler
+            {
+                PooledConnectionLifetime = options.PooledConnectionLifetime,
+                PooledConnectionIdleTimeout = options.PooledConnectionIdleTimeout,
+                AutomaticDecompression = options.AutomaticDecompression,
+            },
+        };
+    }
+
+    private static bool IsTransientFailure(Outcome<HttpResponseMessage> outcome)
+    {
+        if (outcome.Exception is null)
+        {
+            return outcome.Result is not null
+                && (int)outcome.Result.StatusCode is 408 or 429 or >= 500;
+        }
+
+        // Retry timeouts (cancellation with an inner TimeoutException), not caller cancellation or an open circuit.
+        return outcome.Exception switch
+        {
+            OperationCanceledException canceled => canceled.InnerException is TimeoutException,
+            BrokenCircuitException => false,
+            _ => true,
+        };
+    }
+
+    private static string FormatOutcome(Outcome<HttpResponseMessage> outcome) =>
+        outcome.Exception?.Message ?? outcome.Result?.StatusCode.ToString() ?? "unknown";
+}

--- a/Utilities/HttpClientOptions.cs
+++ b/Utilities/HttpClientOptions.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace ptr727.Utilities;
+
+/// <summary>
+/// Configuration options for <see cref="HttpClientFactory"/>, with best-practice defaults.
+/// </summary>
+/// <remarks>
+/// Every option has a sensible default, so a caller overrides only what they need. Defaults
+/// are chosen for general-purpose resilient HTTP access and can be tuned per client.
+/// </remarks>
+public sealed class HttpClientOptions
+{
+    /// <summary>
+    /// Gets or sets the maximum number of retry attempts for transient failures. Default is 3.
+    /// </summary>
+    public int RetryMaxAttempts { get; set; } = 3;
+
+    /// <summary>
+    /// Gets or sets the base delay between retries. Default is 1 second.
+    /// </summary>
+    public TimeSpan RetryBaseDelay { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Gets or sets the maximum delay between retries. Default is 30 seconds.
+    /// </summary>
+    public TimeSpan RetryMaxDelay { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Gets or sets the failure ratio that trips the circuit breaker. Default is 0.1 (10 percent).
+    /// </summary>
+    public double CircuitBreakerFailureRatio { get; set; } = 0.1;
+
+    /// <summary>
+    /// Gets or sets the minimum throughput before the circuit breaker can trip. Default is 10.
+    /// </summary>
+    public int CircuitBreakerMinimumThroughput { get; set; } = 10;
+
+    /// <summary>
+    /// Gets or sets the sampling duration over which failures are measured. Default is 60 seconds.
+    /// </summary>
+    public TimeSpan CircuitBreakerSamplingDuration { get; set; } = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Gets or sets the duration the circuit stays open once tripped. Default is 30 seconds.
+    /// </summary>
+    public TimeSpan CircuitBreakerBreakDuration { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Gets or sets how long a pooled connection is reused before being recycled. Default is 15 minutes.
+    /// </summary>
+    public TimeSpan PooledConnectionLifetime { get; set; } = TimeSpan.FromMinutes(15);
+
+    /// <summary>
+    /// Gets or sets how long an idle pooled connection is kept before being closed. Default is 2 minutes.
+    /// </summary>
+    public TimeSpan PooledConnectionIdleTimeout { get; set; } = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// Gets or sets the automatic decompression methods. Default is <see cref="DecompressionMethods.All"/>.
+    /// </summary>
+    public DecompressionMethods AutomaticDecompression { get; set; } = DecompressionMethods.All;
+
+    /// <summary>
+    /// Gets or sets the overall HTTP request timeout. Default is 120 seconds.
+    /// </summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(120);
+
+    /// <summary>
+    /// Gets or sets the User-Agent header value. When null, <see cref="AssemblyInfo.DefaultUserAgent"/> is used.
+    /// </summary>
+    public ProductInfoHeaderValue? UserAgent { get; set; }
+
+    /// <summary>
+    /// Gets or sets the base address applied to the created client. When null, no base address is set.
+    /// </summary>
+    public Uri? BaseAddress { get; set; }
+}

--- a/Utilities/StringCompression.cs
+++ b/Utilities/StringCompression.cs
@@ -59,13 +59,8 @@ public static class StringCompression
 
         using MemoryStream uncompressedStream = new(Encoding.UTF8.GetBytes(uncompressedString));
         using MemoryStream compressedStream = new();
-        await using (
-            DeflateStream compressorStream = new(
-                compressedStream,
-                compressionLevel,
-                leaveOpen: true
-            )
-        )
+        DeflateStream compressorStream = new(compressedStream, compressionLevel, leaveOpen: true);
+        await using (compressorStream.ConfigureAwait(false))
         {
             await uncompressedStream
                 .CopyToAsync(compressorStream, cancellationToken)
@@ -117,9 +112,8 @@ public static class StringCompression
 
         using MemoryStream compressedStream = new(Convert.FromBase64String(compressedString));
         using MemoryStream decompressedStream = new();
-        await using (
-            DeflateStream decompressorStream = new(compressedStream, CompressionMode.Decompress)
-        )
+        DeflateStream decompressorStream = new(compressedStream, CompressionMode.Decompress);
+        await using (decompressorStream.ConfigureAwait(false))
         {
             await decompressorStream
                 .CopyToAsync(decompressedStream, cancellationToken)

--- a/Utilities/StringHistory.cs
+++ b/Utilities/StringHistory.cs
@@ -12,7 +12,7 @@ public class StringHistory
     /// <summary>
     /// Initializes a new instance of the <see cref="StringHistory"/> class with no limits.
     /// </summary>
-    public StringHistory() { }
+    public StringHistory() => StringList = _stringList.AsReadOnly();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="StringHistory"/> class with specified limits.
@@ -20,6 +20,7 @@ public class StringHistory
     /// <param name="maxFirstLines">Maximum number of first lines to retain.</param>
     /// <param name="maxLastLines">Maximum number of last lines to retain.</param>
     public StringHistory(int maxFirstLines, int maxLastLines)
+        : this()
     {
         MaxFirstLines = maxFirstLines;
         MaxLastLines = maxLastLines;
@@ -37,14 +38,14 @@ public class StringHistory
         // No restrictions
         if (MaxFirstLines == 0 && MaxLastLines == 0)
         {
-            StringList.Add(value);
+            _stringList.Add(value);
             return;
         }
 
         // Restrict first lines
         if (_firstLines < MaxFirstLines)
         {
-            StringList.Add(value);
+            _stringList.Add(value);
             _firstLines++;
             return;
         }
@@ -58,14 +59,14 @@ public class StringHistory
         // Restrict last lines
         if (_lastLines < MaxLastLines)
         {
-            StringList.Add(value);
+            _stringList.Add(value);
             _lastLines++;
             return;
         }
 
         // Roll the last lines
-        StringList.RemoveAt(MaxFirstLines);
-        StringList.Add(value);
+        _stringList.RemoveAt(MaxFirstLines);
+        _stringList.Add(value);
     }
 
     /// <summary>
@@ -73,8 +74,8 @@ public class StringHistory
     /// </summary>
     /// <returns>A string containing all stored lines.</returns>
     public override string ToString() =>
-        string.Join(Environment.NewLine, StringList)
-        + (StringList.Count > 0 ? Environment.NewLine : string.Empty);
+        string.Join(Environment.NewLine, _stringList)
+        + (_stringList.Count > 0 ? Environment.NewLine : string.Empty);
 
     /// <summary>
     /// Gets or sets the maximum number of first lines to retain.
@@ -91,8 +92,9 @@ public class StringHistory
     /// <summary>
     /// Gets the list of stored strings.
     /// </summary>
-    public List<string> StringList { get; } = [];
+    public ReadOnlyCollection<string> StringList { get; }
 
+    private readonly List<string> _stringList = [];
     private int _firstLines;
     private int _lastLines;
 }

--- a/Utilities/StringHistory.cs
+++ b/Utilities/StringHistory.cs
@@ -90,7 +90,7 @@ public class StringHistory
     public int MaxLastLines { get; set; }
 
     /// <summary>
-    /// Gets the list of stored strings.
+    /// Gets the read-only collection of stored strings.
     /// </summary>
     public ReadOnlyCollection<string> StringList { get; }
 

--- a/Utilities/Utilities.csproj
+++ b/Utilities/Utilities.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PublishAot>true</PublishAot>
+    <PublishAot>false</PublishAot>
     <InvariantGlobalization>false</InvariantGlobalization>
-    <VerifyReferenceAotCompatibility>true</VerifyReferenceAotCompatibility>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -25,7 +24,19 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+  <!-- Microsoft.Extensions.Http.Resilience (Polly) is not annotated AOT-clean, so reference
+       AOT verification would fail the warnings-as-errors build. Gate it behind an explicit
+       PublishAot opt-in; the Sandbox project carries the end-to-end Native AOT proof.
+       IL3058 only reports that the Polly reference graph (Polly.Core, Polly.Extensions,
+       Polly.RateLimiting, Microsoft.Extensions.ObjectPool, System.Threading.RateLimiting) is
+       not annotated IsAotCompatible; it is advisory, not a trim or dynamic-code failure. The
+       Sandbox AOT publish and run is the authoritative proof that the pipeline works under AOT. -->
+  <PropertyGroup Condition="'$(PublishAot)' == 'true'">
+    <VerifyReferenceAotCompatibility>true</VerifyReferenceAotCompatibility>
+    <NoWarn>$(NoWarn);IL3058</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>

--- a/UtilitiesTests/.editorconfig
+++ b/UtilitiesTests/.editorconfig
@@ -8,3 +8,6 @@ dotnet_diagnostic.CA1707.severity = none
 
 # CA1515: xUnit discovers only public test classes, so they cannot be internal.
 dotnet_diagnostic.CA1515.severity = none
+
+# CA2007: xUnit forbids ConfigureAwait in test methods (xUnit1030), so CA2007 cannot be satisfied in test code.
+dotnet_diagnostic.CA2007.severity = none

--- a/UtilitiesTests/.editorconfig
+++ b/UtilitiesTests/.editorconfig
@@ -3,18 +3,8 @@ root = false
 # C# files
 [*.cs]
 
-# Allow underscores in test method names
+# CA1707: xUnit test method names use underscores (Method_Scenario_Expected).
 dotnet_diagnostic.CA1707.severity = none
 
-# Test-scoped analyzer exceptions: rules that target production-code concerns
-# and don't apply to xUnit test code. Each is documented, not a brownfield
-# blanket-relax (see CODESTYLE.md "Analyzer Diagnostics and Suppressions").
-# CA1515: xUnit requires public test classes, so they can't be made internal.
-dotnet_diagnostic.CA1515.severity = suggestion
-# CA1849: synchronous calls inside async test paths are kept intentionally.
-dotnet_diagnostic.CA1849.severity = suggestion
-# CA2000: test disposable ownership is transferred or scoped to the test, so
-#   scope-based disposal analysis reports false positives.
-dotnet_diagnostic.CA2000.severity = suggestion
-# CA5394: Random in tests is for test data, not security.
-dotnet_diagnostic.CA5394.severity = suggestion
+# CA1515: xUnit discovers only public test classes, so they cannot be internal.
+dotnet_diagnostic.CA1515.severity = none

--- a/UtilitiesTests/AssemblyInfoTests.cs
+++ b/UtilitiesTests/AssemblyInfoTests.cs
@@ -1,0 +1,32 @@
+using System.Net.Http.Headers;
+
+namespace ptr727.Utilities.Tests;
+
+public class AssemblyInfoTests
+{
+    [Fact]
+    public void For_WithMarkerType_ReturnsDefiningAssembly()
+    {
+        _ = AssemblyInfo.For<HttpClientOptions>().Should().BeSameAs(typeof(AssemblyInfo).Assembly);
+        _ = AssemblyInfo
+            .For<AssemblyInfoTests>()
+            .Should()
+            .BeSameAs(typeof(AssemblyInfoTests).Assembly);
+    }
+
+    [Fact]
+    public void AppName_IsNotNullOrEmpty() => _ = AssemblyInfo.AppName.Should().NotBeNullOrEmpty();
+
+    [Fact]
+    public void AppVersion_IsNotNullOrEmpty() =>
+        _ = AssemblyInfo.AppVersion.Should().NotBeNullOrEmpty();
+
+    [Fact]
+    public void DefaultUserAgent_ParsesToAppIdentity()
+    {
+        ProductInfoHeaderValue userAgent = AssemblyInfo.DefaultUserAgent;
+
+        _ = userAgent.Should().NotBeNull();
+        _ = userAgent.ToString().Should().NotBeNullOrEmpty();
+    }
+}

--- a/UtilitiesTests/ConsoleTests.cs
+++ b/UtilitiesTests/ConsoleTests.cs
@@ -5,33 +5,39 @@ public class ConsoleTests
     [Fact]
     public void WriteLineColor_WithValidString_ShouldContainMessage()
     {
-        StringWriter output = new();
+        TextWriter originalOutput = Console.Out;
+        using StringWriter output = new();
         Console.SetOut(output);
+        try
+        {
+            ConsoleEx.WriteLineColor(ConsoleColor.Green, "Test message");
 
-        ConsoleEx.WriteLineColor(ConsoleColor.Green, "Test message");
-
-        string result = output.ToString();
-        _ = result.Should().Contain("Test message");
-
-        // Reset console
-        StreamWriter standardOutput = new(Console.OpenStandardOutput()) { AutoFlush = true };
-        Console.SetOut(standardOutput);
+            string result = output.ToString();
+            _ = result.Should().Contain("Test message");
+        }
+        finally
+        {
+            Console.SetOut(originalOutput);
+        }
     }
 
     [Fact]
     public void WriteLineColor_WithEmptyString_ShouldNotThrow()
     {
-        StringWriter output = new();
+        TextWriter originalOutput = Console.Out;
+        using StringWriter output = new();
         Console.SetOut(output);
+        try
+        {
+            ConsoleEx.WriteLineColor(ConsoleColor.Green, string.Empty);
 
-        ConsoleEx.WriteLineColor(ConsoleColor.Green, string.Empty);
-
-        string result = output.ToString();
-        _ = result.Should().NotBeNull();
-
-        // Reset console
-        StreamWriter standardOutput = new(Console.OpenStandardOutput()) { AutoFlush = true };
-        Console.SetOut(standardOutput);
+            string result = output.ToString();
+            _ = result.Should().NotBeNull();
+        }
+        finally
+        {
+            Console.SetOut(originalOutput);
+        }
     }
 
     [Fact]
@@ -48,65 +54,77 @@ public class ConsoleTests
     [Fact]
     public void WriteLineError_WithString_ShouldContainMessage()
     {
-        StringWriter output = new();
+        TextWriter originalOutput = Console.Out;
+        using StringWriter output = new();
         Console.SetOut(output);
+        try
+        {
+            ConsoleEx.WriteLineError("Error message");
 
-        ConsoleEx.WriteLineError("Error message");
-
-        string result = output.ToString();
-        _ = result.Should().Contain("Error message");
-
-        // Reset console
-        StreamWriter standardOutput = new(Console.OpenStandardOutput()) { AutoFlush = true };
-        Console.SetOut(standardOutput);
+            string result = output.ToString();
+            _ = result.Should().Contain("Error message");
+        }
+        finally
+        {
+            Console.SetOut(originalOutput);
+        }
     }
 
     [Fact]
     public void WriteLineEvent_WithString_ShouldContainMessage()
     {
-        StringWriter output = new();
+        TextWriter originalOutput = Console.Out;
+        using StringWriter output = new();
         Console.SetOut(output);
+        try
+        {
+            ConsoleEx.WriteLineEvent("Event message");
 
-        ConsoleEx.WriteLineEvent("Event message");
-
-        string result = output.ToString();
-        _ = result.Should().Contain("Event message");
-
-        // Reset console
-        StreamWriter standardOutput = new(Console.OpenStandardOutput()) { AutoFlush = true };
-        Console.SetOut(standardOutput);
+            string result = output.ToString();
+            _ = result.Should().Contain("Event message");
+        }
+        finally
+        {
+            Console.SetOut(originalOutput);
+        }
     }
 
     [Fact]
     public void WriteLineTool_WithString_ShouldContainMessage()
     {
-        StringWriter output = new();
+        TextWriter originalOutput = Console.Out;
+        using StringWriter output = new();
         Console.SetOut(output);
+        try
+        {
+            ConsoleEx.WriteLineTool("Tool message");
 
-        ConsoleEx.WriteLineTool("Tool message");
-
-        string result = output.ToString();
-        _ = result.Should().Contain("Tool message");
-
-        // Reset console
-        StreamWriter standardOutput = new(Console.OpenStandardOutput()) { AutoFlush = true };
-        Console.SetOut(standardOutput);
+            string result = output.ToString();
+            _ = result.Should().Contain("Tool message");
+        }
+        finally
+        {
+            Console.SetOut(originalOutput);
+        }
     }
 
     [Fact]
     public void WriteLine_WithString_ShouldContainMessage()
     {
-        StringWriter output = new();
+        TextWriter originalOutput = Console.Out;
+        using StringWriter output = new();
         Console.SetOut(output);
+        try
+        {
+            ConsoleEx.WriteLine("Output message");
 
-        ConsoleEx.WriteLine("Output message");
-
-        string result = output.ToString();
-        _ = result.Should().Contain("Output message");
-
-        // Reset console
-        StreamWriter standardOutput = new(Console.OpenStandardOutput()) { AutoFlush = true };
-        Console.SetOut(standardOutput);
+            string result = output.ToString();
+            _ = result.Should().Contain("Output message");
+        }
+        finally
+        {
+            Console.SetOut(originalOutput);
+        }
     }
 
     [Theory]
@@ -116,14 +134,17 @@ public class ConsoleTests
     [InlineData(ConsoleColor.Cyan)]
     public void WriteLineColor_WithDifferentColors_ShouldNotThrow(ConsoleColor color)
     {
-        StringWriter output = new();
+        TextWriter originalOutput = Console.Out;
+        using StringWriter output = new();
         Console.SetOut(output);
-
-        ConsoleEx.WriteLineColor(color, "Test");
-
-        // Reset console
-        StreamWriter standardOutput = new(Console.OpenStandardOutput()) { AutoFlush = true };
-        Console.SetOut(standardOutput);
+        try
+        {
+            ConsoleEx.WriteLineColor(color, "Test");
+        }
+        finally
+        {
+            Console.SetOut(originalOutput);
+        }
     }
 
     [Fact]

--- a/UtilitiesTests/ExtensionsTests.cs
+++ b/UtilitiesTests/ExtensionsTests.cs
@@ -72,7 +72,7 @@ public class ExtensionsTests
     public async Task StringExtension_CompressAsync_WithCancellation_ShouldRespectToken()
     {
         using CancellationTokenSource cts = new();
-        cts.Cancel();
+        await cts.CancelAsync();
         string original = "Test string";
 
         _ = await FluentActions

--- a/UtilitiesTests/FileExAsyncTests.cs
+++ b/UtilitiesTests/FileExAsyncTests.cs
@@ -199,7 +199,7 @@ public class FileExAsyncTests
     {
         string tempFile = Path.GetTempFileName();
         using CancellationTokenSource cts = new();
-        cts.Cancel(); // Cancel immediately
+        await cts.CancelAsync(); // Cancel immediately
 
         try
         {

--- a/UtilitiesTests/HttpClientFactoryResilienceTests.cs
+++ b/UtilitiesTests/HttpClientFactoryResilienceTests.cs
@@ -66,6 +66,34 @@ public class HttpClientFactoryResilienceTests
         _ = stub.CallCount.Should().Be(1); // no retry on cancellation
     }
 
+    [Fact]
+    public async Task NetworkException_IsRetried()
+    {
+        using StubHttpMessageHandler stub = new(Throws(new HttpRequestException("network")));
+        HttpClientOptions options = FastOptions();
+        options.RetryMaxAttempts = 2;
+        using HttpClient client = CreateStubbedClient(stub, options);
+
+        _ = await FluentActions
+            .Awaiting(() => client.GetAsync(new Uri("http://localhost/")))
+            .Should()
+            .ThrowAsync<HttpRequestException>();
+        _ = stub.CallCount.Should().Be(3); // initial attempt + 2 retries
+    }
+
+    [Fact]
+    public async Task NonTransientException_IsNotRetried()
+    {
+        using StubHttpMessageHandler stub = new(Throws(new InvalidOperationException("bug")));
+        using HttpClient client = CreateStubbedClient(stub, FastOptions());
+
+        _ = await FluentActions
+            .Awaiting(() => client.GetAsync(new Uri("http://localhost/")))
+            .Should()
+            .ThrowAsync<InvalidOperationException>();
+        _ = stub.CallCount.Should().Be(1); // programming errors are not retried
+    }
+
     private static HttpClientOptions FastOptions() =>
         new()
         {

--- a/UtilitiesTests/HttpClientFactoryResilienceTests.cs
+++ b/UtilitiesTests/HttpClientFactoryResilienceTests.cs
@@ -1,0 +1,131 @@
+using System.Net;
+
+namespace ptr727.Utilities.Tests;
+
+public class HttpClientFactoryResilienceTests
+{
+    [Fact]
+    public async Task TransientStatus_IsRetriedThenSucceeds()
+    {
+        using StubHttpMessageHandler stub = new(
+            Status(HttpStatusCode.InternalServerError),
+            Status(HttpStatusCode.ServiceUnavailable),
+            Status(HttpStatusCode.OK)
+        );
+        using HttpClient client = CreateStubbedClient(stub, FastOptions());
+
+        using HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/"));
+
+        _ = response.StatusCode.Should().Be(HttpStatusCode.OK);
+        _ = stub.CallCount.Should().Be(3); // initial attempt + 2 retries
+    }
+
+    [Fact]
+    public async Task NonTransientStatus_IsNotRetried()
+    {
+        using StubHttpMessageHandler stub = new(Status(HttpStatusCode.NotFound));
+        using HttpClient client = CreateStubbedClient(stub, FastOptions());
+
+        using HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/"));
+
+        _ = response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        _ = stub.CallCount.Should().Be(1); // 404 is not transient
+    }
+
+    [Fact]
+    public async Task Timeout_IsRetried()
+    {
+        // A request timeout surfaces as a cancellation carrying an inner TimeoutException.
+        using StubHttpMessageHandler stub = new(
+            Throws(new TaskCanceledException("timeout", new TimeoutException()))
+        );
+        HttpClientOptions options = FastOptions();
+        options.RetryMaxAttempts = 2;
+        using HttpClient client = CreateStubbedClient(stub, options);
+
+        _ = await FluentActions
+            .Awaiting(() => client.GetAsync(new Uri("http://localhost/")))
+            .Should()
+            .ThrowAsync<TaskCanceledException>();
+        _ = stub.CallCount.Should().Be(3); // initial attempt + 2 retries
+    }
+
+    [Fact]
+    public async Task CallerCancellation_IsNotRetried()
+    {
+        // Caller-requested cancellation is not transient and must not be retried.
+        using StubHttpMessageHandler stub = new(
+            Throws(new OperationCanceledException("cancelled"))
+        );
+        using HttpClient client = CreateStubbedClient(stub, FastOptions());
+
+        _ = await FluentActions
+            .Awaiting(() => client.GetAsync(new Uri("http://localhost/")))
+            .Should()
+            .ThrowAsync<OperationCanceledException>();
+        _ = stub.CallCount.Should().Be(1); // no retry on cancellation
+    }
+
+    private static HttpClientOptions FastOptions() =>
+        new()
+        {
+            RetryBaseDelay = TimeSpan.FromMilliseconds(1),
+            RetryMaxDelay = TimeSpan.FromMilliseconds(5),
+        };
+
+    private static Func<Task<HttpResponseMessage>> Status(HttpStatusCode statusCode) =>
+        () => Task.FromResult(new HttpResponseMessage(statusCode));
+
+    private static Func<Task<HttpResponseMessage>> Throws(Exception exception) =>
+        () => Task.FromException<HttpResponseMessage>(exception);
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "Ownership of the handler chain transfers to the returned HttpClient, which the caller disposes."
+    )]
+    private static HttpClient CreateStubbedClient(
+        StubHttpMessageHandler stub,
+        HttpClientOptions options
+    )
+    {
+        DelegatingHandler resilience = HttpClientFactory.CreateResilienceHandler(options);
+
+        // Replace the factory's real network handler with the stub transport.
+        resilience.InnerHandler?.Dispose();
+        resilience.InnerHandler = stub;
+
+        return new HttpClient(resilience);
+    }
+}
+
+/// <summary>
+/// A stub HTTP transport that returns a scripted sequence of results and counts calls. The last
+/// step repeats once the sequence is exhausted, so a single step models a repeating outcome.
+/// </summary>
+internal sealed class StubHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Queue<Func<Task<HttpResponseMessage>>> _steps;
+
+    internal StubHttpMessageHandler(params Func<Task<HttpResponseMessage>>[] steps)
+    {
+        ArgumentNullException.ThrowIfNull(steps);
+        if (steps.Length == 0)
+        {
+            throw new ArgumentException("At least one step is required.", nameof(steps));
+        }
+
+        _steps = new Queue<Func<Task<HttpResponseMessage>>>(steps);
+    }
+
+    internal int CallCount { get; private set; }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken
+    )
+    {
+        CallCount++;
+        return (_steps.Count > 1 ? _steps.Dequeue() : _steps.Peek())();
+    }
+}

--- a/UtilitiesTests/HttpClientFactoryResilienceTests.cs
+++ b/UtilitiesTests/HttpClientFactoryResilienceTests.cs
@@ -94,6 +94,41 @@ public class HttpClientFactoryResilienceTests
         _ = stub.CallCount.Should().Be(1); // programming errors are not retried
     }
 
+    [Fact]
+    public async Task HttpRequestExceptionWithNonTransientStatus_IsNotRetried()
+    {
+        using StubHttpMessageHandler stub = new(
+            Throws(new HttpRequestException("not found", null, HttpStatusCode.NotFound))
+        );
+        using HttpClient client = CreateStubbedClient(stub, FastOptions());
+
+        _ = await FluentActions
+            .Awaiting(() => client.GetAsync(new Uri("http://localhost/")))
+            .Should()
+            .ThrowAsync<HttpRequestException>();
+        _ = stub.CallCount.Should().Be(1); // a 404 HttpRequestException is not transient
+    }
+
+    [Fact]
+    public async Task HttpRequestExceptionWithTransientStatus_IsRetriedThenSucceeds()
+    {
+        using StubHttpMessageHandler stub = new(
+            Throws(
+                new HttpRequestException("unavailable", null, HttpStatusCode.ServiceUnavailable)
+            ),
+            Throws(
+                new HttpRequestException("unavailable", null, HttpStatusCode.ServiceUnavailable)
+            ),
+            Status(HttpStatusCode.OK)
+        );
+        using HttpClient client = CreateStubbedClient(stub, FastOptions());
+
+        using HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/"));
+
+        _ = response.StatusCode.Should().Be(HttpStatusCode.OK);
+        _ = stub.CallCount.Should().Be(3); // 503 exception retried, then success
+    }
+
     private static HttpClientOptions FastOptions() =>
         new()
         {

--- a/UtilitiesTests/HttpClientFactoryTests.cs
+++ b/UtilitiesTests/HttpClientFactoryTests.cs
@@ -1,0 +1,78 @@
+using System.Net.Http.Headers;
+
+namespace ptr727.Utilities.Tests;
+
+public class HttpClientFactoryTests
+{
+    [Fact]
+    public void GetClient_ReturnsSharedSingleton()
+    {
+        HttpClient first = HttpClientFactory.GetClient();
+        HttpClient second = HttpClientFactory.GetClient();
+
+        _ = first.Should().NotBeNull();
+        _ = first.Should().BeSameAs(second);
+    }
+
+    [Fact]
+    public void CreateClient_WithDefaults_ReturnsIndependentClients()
+    {
+        using HttpClient first = HttpClientFactory.CreateClient();
+        using HttpClient second = HttpClientFactory.CreateClient();
+
+        _ = first.Should().NotBeNull();
+        _ = first.Should().NotBeSameAs(second);
+    }
+
+    [Fact]
+    public void CreateClient_WithDefaults_UsesDefaultUserAgent()
+    {
+        using HttpClient client = HttpClientFactory.CreateClient();
+
+        _ = client.DefaultRequestHeaders.UserAgent.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void CreateClient_WithUserAgent_AppliesUserAgent()
+    {
+        ProductInfoHeaderValue userAgent = new("Sample", "9.9");
+
+        using HttpClient client = HttpClientFactory.CreateClient(userAgent);
+
+        _ = client.DefaultRequestHeaders.UserAgent.Should().Contain(userAgent);
+    }
+
+    [Fact]
+    public void CreateClient_WithNullUserAgent_Throws()
+    {
+        ProductInfoHeaderValue? userAgent = null;
+
+        _ = FluentActions
+            .Invoking(() => HttpClientFactory.CreateClient(userAgent!))
+            .Should()
+            .Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void CreateClient_WithOptions_AppliesTimeoutAndBaseAddress()
+    {
+        HttpClientOptions options = new()
+        {
+            Timeout = TimeSpan.FromSeconds(42),
+            BaseAddress = new Uri("https://example.com/"),
+        };
+
+        using HttpClient client = HttpClientFactory.CreateClient(options);
+
+        _ = client.Timeout.Should().Be(TimeSpan.FromSeconds(42));
+        _ = client.BaseAddress.Should().Be(options.BaseAddress);
+    }
+
+    [Fact]
+    public void CreateResilienceHandler_ReturnsHandler()
+    {
+        using DelegatingHandler handler = HttpClientFactory.CreateResilienceHandler();
+
+        _ = handler.Should().NotBeNull();
+    }
+}

--- a/UtilitiesTests/HttpClientFactoryTests.cs
+++ b/UtilitiesTests/HttpClientFactoryTests.cs
@@ -33,24 +33,15 @@ public class HttpClientFactoryTests
     }
 
     [Fact]
-    public void CreateClient_WithUserAgent_AppliesUserAgent()
+    public void CreateClient_WithUserAgentOption_AppliesUserAgent()
     {
         ProductInfoHeaderValue userAgent = new("Sample", "9.9");
 
-        using HttpClient client = HttpClientFactory.CreateClient(userAgent);
+        using HttpClient client = HttpClientFactory.CreateClient(
+            new HttpClientOptions { UserAgent = userAgent }
+        );
 
         _ = client.DefaultRequestHeaders.UserAgent.Should().Contain(userAgent);
-    }
-
-    [Fact]
-    public void CreateClient_WithNullUserAgent_Throws()
-    {
-        ProductInfoHeaderValue? userAgent = null;
-
-        _ = FluentActions
-            .Invoking(() => HttpClientFactory.CreateClient(userAgent!))
-            .Should()
-            .Throw<ArgumentNullException>();
     }
 
     [Fact]

--- a/UtilitiesTests/HttpClientOptionsTests.cs
+++ b/UtilitiesTests/HttpClientOptionsTests.cs
@@ -1,0 +1,26 @@
+using System.Net;
+
+namespace ptr727.Utilities.Tests;
+
+public class HttpClientOptionsTests
+{
+    [Fact]
+    public void Defaults_MatchBestPracticeValues()
+    {
+        HttpClientOptions options = new();
+
+        _ = options.RetryMaxAttempts.Should().Be(3);
+        _ = options.RetryBaseDelay.Should().Be(TimeSpan.FromSeconds(1));
+        _ = options.RetryMaxDelay.Should().Be(TimeSpan.FromSeconds(30));
+        _ = options.CircuitBreakerFailureRatio.Should().Be(0.1);
+        _ = options.CircuitBreakerMinimumThroughput.Should().Be(10);
+        _ = options.CircuitBreakerSamplingDuration.Should().Be(TimeSpan.FromSeconds(60));
+        _ = options.CircuitBreakerBreakDuration.Should().Be(TimeSpan.FromSeconds(30));
+        _ = options.PooledConnectionLifetime.Should().Be(TimeSpan.FromMinutes(15));
+        _ = options.PooledConnectionIdleTimeout.Should().Be(TimeSpan.FromMinutes(2));
+        _ = options.AutomaticDecompression.Should().Be(DecompressionMethods.All);
+        _ = options.Timeout.Should().Be(TimeSpan.FromSeconds(120));
+        _ = options.UserAgent.Should().BeNull();
+        _ = options.BaseAddress.Should().BeNull();
+    }
+}

--- a/UtilitiesTests/StringCompressionAsyncTests.cs
+++ b/UtilitiesTests/StringCompressionAsyncTests.cs
@@ -1,4 +1,5 @@
 using System.IO.Compression;
+using System.Security.Cryptography;
 
 namespace ptr727.Utilities.Tests;
 
@@ -8,10 +9,8 @@ public class StringCompressionAsyncTests
     public async Task CompressDecompressAsync()
     {
         // Create random string
-        Random random = new();
-        int length = random.Next(64 * 1024);
-        byte[] buffer = new byte[length];
-        random.NextBytes(buffer);
+        int length = RandomNumberGenerator.GetInt32(64 * 1024);
+        byte[] buffer = RandomNumberGenerator.GetBytes(length);
         string text = Convert.ToBase64String(buffer);
 
         // Compress the string asynchronously

--- a/UtilitiesTests/StringCompressionTests.cs
+++ b/UtilitiesTests/StringCompressionTests.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+
 namespace ptr727.Utilities.Tests;
 
 public class StringCompressionTests
@@ -6,10 +8,8 @@ public class StringCompressionTests
     public void CompressDecompress()
     {
         // Create random string
-        Random random = new();
-        int length = random.Next(64 * 1024);
-        byte[] buffer = new byte[length];
-        random.NextBytes(buffer);
+        int length = RandomNumberGenerator.GetInt32(64 * 1024);
+        byte[] buffer = RandomNumberGenerator.GetBytes(length);
         string text = Convert.ToBase64String(buffer);
 
         // Compress the string

--- a/cspell.json
+++ b/cspell.json
@@ -12,6 +12,7 @@
     "nbgv",
     "Nerdbank",
     "nupkg",
+    "Polly",
     "Serilog",
     "Simoncic",
     "softprops",

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-	"version": "3.7",
+	"version": "4.0",
 	"publicReleaseRefSpec": [
 		"^refs/heads/main$"
 	],


### PR DESCRIPTION
Promotes v4.0 to main for a stable release.

## Included

- **HttpClientFactory** - reusable resilient HTTP client factory (Polly retry + circuit breaker, connection pooling), with `HttpClientOptions` for tuning and both a shared client and a resilience-handler surface.
- **AssemblyInfo** - AOT-safe identity helper; `For<T>()` substitutes for `Assembly.GetExecutingAssembly()` (Native AOT), plus app name/version and a default User-Agent.
- **Download** routed through the factory (signatures unchanged).
- `List<T>` public members changed to `Collection<T>` / `ReadOnlyCollection<T>` (breaking API change).
- Library AOT verification gated behind `PublishAot`; Sandbox is a Native AOT smoke test proving the pipeline and identity resolution under AOT.
- Deterministic mocked resilience tests exercising the Polly pipeline offline.
- CA1002/CA2007 and test-code analyzer cleanups.

See [HISTORY.md](./HISTORY.md) for the full v4.0 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)