### PR TITLE
Retry only known-transient exceptions in the resilience pipeline

### DIFF
--- a/Utilities/HttpClientFactory.cs
+++ b/Utilities/HttpClientFactory.cs
@@ -180,12 +180,14 @@ public static class HttpClientFactory
                 && (int)outcome.Result.StatusCode is 408 or 429 or >= 500;
         }
 
-        // Retry timeouts (cancellation with an inner TimeoutException), not caller cancellation or an open circuit.
+        // Retry only known-transient failures: a timeout (a cancellation with an inner
+        // TimeoutException) or a network/IO error. Caller cancellation, an open circuit, and any
+        // other exception (including programming errors) are not retried.
         return outcome.Exception switch
         {
             OperationCanceledException canceled => canceled.InnerException is TimeoutException,
-            BrokenCircuitException => false,
-            _ => true,
+            HttpRequestException or IOException => true,
+            _ => false,
         };
     }
 

--- a/UtilitiesTests/HttpClientFactoryResilienceTests.cs
+++ b/UtilitiesTests/HttpClientFactoryResilienceTests.cs
@@ -66,6 +66,34 @@ public class HttpClientFactoryResilienceTests
         _ = stub.CallCount.Should().Be(1); // no retry on cancellation
     }
 
+    [Fact]
+    public async Task NetworkException_IsRetried()
+    {
+        using StubHttpMessageHandler stub = new(Throws(new HttpRequestException("network")));
+        HttpClientOptions options = FastOptions();
+        options.RetryMaxAttempts = 2;
+        using HttpClient client = CreateStubbedClient(stub, options);
+
+        _ = await FluentActions
+            .Awaiting(() => client.GetAsync(new Uri("http://localhost/")))
+            .Should()
+            .ThrowAsync<HttpRequestException>();
+        _ = stub.CallCount.Should().Be(3); // initial attempt + 2 retries
+    }
+
+    [Fact]
+    public async Task NonTransientException_IsNotRetried()
+    {
+        using StubHttpMessageHandler stub = new(Throws(new InvalidOperationException("bug")));
+        using HttpClient client = CreateStubbedClient(stub, FastOptions());
+
+        _ = await FluentActions
+            .Awaiting(() => client.GetAsync(new Uri("http://localhost/")))
+            .Should()
+            .ThrowAsync<InvalidOperationException>();
+        _ = stub.CallCount.Should().Be(1); // programming errors are not retried
+    }
+
     private static HttpClientOptions FastOptions() =>
         new()
         {


### PR DESCRIPTION
## Summary

Narrows `HttpClientFactory.IsTransientFailure` so the retry pipeline handles only known-transient failures instead of defaulting unknown exceptions to transient (`_ => true`). Retrying arbitrary exceptions - including programming errors like `ArgumentException`/`InvalidOperationException` - masks bugs and adds needless load.

Now transient means:
- Transient HTTP status (408, 429, >= 500).
- A request timeout (a cancellation carrying an inner `TimeoutException`).
- A network/IO error (`HttpRequestException`, `IOException`).

Everything else - caller cancellation, an open circuit, and any other exception - is not retried. This aligns with the `Microsoft.Extensions.Http.Resilience` transient defaults.

## Tests

Adds two deterministic mocked tests: a network exception is retried; a non-transient (`InvalidOperationException`) is not.

## Verification

- `dotnet build` - 0 warnings / 0 errors.
- `dotnet test` - 151 passed (+2).
- `dotnet format style --verify-no-changes` clean.

Addresses a Copilot finding on the develop->main release PR (#394).

🤖 Generated with [Claude Code](https://claude.com/claude-code)