### PR TITLE
Remove ambiguous CreateClient user-agent overload

### DIFF
--- a/Utilities/HttpClientFactory.cs
+++ b/Utilities/HttpClientFactory.cs
@@ -1,4 +1,3 @@
-using System.Net.Http.Headers;
 using Microsoft.Extensions.Http.Resilience;
 using Polly;
 using Polly.CircuitBreaker;
@@ -74,19 +73,6 @@ public static class HttpClientFactory
         );
 
         return client;
-    }
-
-    /// <summary>
-    /// Creates a new caller-owned <see cref="HttpClient"/> with the specified User-Agent and default options.
-    /// </summary>
-    /// <param name="userAgent">The User-Agent header value to use.</param>
-    /// <returns>A configured HttpClient. The caller owns and should store and reuse the instance.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="userAgent"/> is null.</exception>
-    public static HttpClient CreateClient(ProductInfoHeaderValue userAgent)
-    {
-        ArgumentNullException.ThrowIfNull(userAgent);
-
-        return CreateClient(new HttpClientOptions { UserAgent = userAgent });
     }
 
     /// <summary>

--- a/UtilitiesTests/HttpClientFactoryTests.cs
+++ b/UtilitiesTests/HttpClientFactoryTests.cs
@@ -33,24 +33,15 @@ public class HttpClientFactoryTests
     }
 
     [Fact]
-    public void CreateClient_WithUserAgent_AppliesUserAgent()
+    public void CreateClient_WithUserAgentOption_AppliesUserAgent()
     {
         ProductInfoHeaderValue userAgent = new("Sample", "9.9");
 
-        using HttpClient client = HttpClientFactory.CreateClient(userAgent);
+        using HttpClient client = HttpClientFactory.CreateClient(
+            new HttpClientOptions { UserAgent = userAgent }
+        );
 
         _ = client.DefaultRequestHeaders.UserAgent.Should().Contain(userAgent);
-    }
-
-    [Fact]
-    public void CreateClient_WithNullUserAgent_Throws()
-    {
-        ProductInfoHeaderValue? userAgent = null;
-
-        _ = FluentActions
-            .Invoking(() => HttpClientFactory.CreateClient(userAgent!))
-            .Should()
-            .Throw<ArgumentNullException>();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Removes the `HttpClientFactory.CreateClient(ProductInfoHeaderValue)` overload. With `CreateClient(HttpClientOptions? = null)` also present, `CreateClient(null)` was an ambiguous call, an easy public-API foot-gun. Callers set a custom user agent via the options object instead:

```csharp
HttpClientFactory.CreateClient(new HttpClientOptions { UserAgent = ua });
```

No caller used the removed overload (the sibling integrations and `Download` use `GetClient()` / `CreateClient(options)`). The user-agent test is repointed to the options path; the now-moot null-argument test is removed. The unused `System.Net.Http.Headers` using is dropped.

## Verification

- `dotnet build` - 0 warnings / 0 errors.
- `dotnet test` - 150 passed.
- `dotnet format style --verify-no-changes` clean.

Addresses a Copilot finding on the develop->main release PR (#394); done before the stable 4.0 API is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)