### PR TITLE
Fail fast on status-bearing HttpRequestException

### DIFF
--- a/Utilities/HttpClientFactory.cs
+++ b/Utilities/HttpClientFactory.cs
@@ -166,15 +166,14 @@ public static class HttpClientFactory
                 && (int)outcome.Result.StatusCode is 408 or 429 or >= 500;
         }
 
-        // Retry only known-transient failures: a timeout (a cancellation with an inner
-        // TimeoutException) or a network/IO error. Caller cancellation, an open circuit, and any
-        // other exception (including programming errors) are not retried.
+        // Retry known-transient failures: a request timeout (a cancellation with an inner
+        // TimeoutException), a network or IO error (an HttpRequestException with no status, or an
+        // IOException), or an HttpRequestException whose own status code is transient (408, 429,
+        // >= 500). Caller cancellation, an open circuit, a 4xx status, and any other exception
+        // (including programming errors) are not retried.
         return outcome.Exception switch
         {
             OperationCanceledException canceled => canceled.InnerException is TimeoutException,
-            // A network/IO HttpRequestException carries no status; treat it as transient. One that
-            // carries a status (for example from EnsureSuccessStatusCode) is transient only for a
-            // transient status code, so 4xx failures fail fast.
             HttpRequestException { StatusCode: null } or IOException => true,
             HttpRequestException { StatusCode: { } statusCode } => (int)statusCode
                 is 408

--- a/Utilities/HttpClientFactory.cs
+++ b/Utilities/HttpClientFactory.cs
@@ -172,7 +172,14 @@ public static class HttpClientFactory
         return outcome.Exception switch
         {
             OperationCanceledException canceled => canceled.InnerException is TimeoutException,
-            HttpRequestException or IOException => true,
+            // A network/IO HttpRequestException carries no status; treat it as transient. One that
+            // carries a status (for example from EnsureSuccessStatusCode) is transient only for a
+            // transient status code, so 4xx failures fail fast.
+            HttpRequestException { StatusCode: null } or IOException => true,
+            HttpRequestException { StatusCode: { } statusCode } => (int)statusCode
+                is 408
+                    or 429
+                    or >= 500,
             _ => false,
         };
     }

--- a/Utilities/HttpClientFactory.cs
+++ b/Utilities/HttpClientFactory.cs
@@ -163,7 +163,7 @@ public static class HttpClientFactory
         if (outcome.Exception is null)
         {
             return outcome.Result is not null
-                && (int)outcome.Result.StatusCode is 408 or 429 or >= 500;
+                && IsTransientStatusCode((int)outcome.Result.StatusCode);
         }
 
         // Retry known-transient failures: a request timeout (a cancellation with an inner
@@ -175,13 +175,14 @@ public static class HttpClientFactory
         {
             OperationCanceledException canceled => canceled.InnerException is TimeoutException,
             HttpRequestException { StatusCode: null } or IOException => true,
-            HttpRequestException { StatusCode: { } statusCode } => (int)statusCode
-                is 408
-                    or 429
-                    or >= 500,
+            HttpRequestException { StatusCode: { } statusCode } => IsTransientStatusCode(
+                (int)statusCode
+            ),
             _ => false,
         };
     }
+
+    private static bool IsTransientStatusCode(int statusCode) => statusCode is 408 or 429 or >= 500;
 
     private static string FormatOutcome(Outcome<HttpResponseMessage> outcome) =>
         outcome.Exception?.Message ?? outcome.Result?.StatusCode.ToString() ?? "unknown";

--- a/UtilitiesTests/HttpClientFactoryResilienceTests.cs
+++ b/UtilitiesTests/HttpClientFactoryResilienceTests.cs
@@ -109,6 +109,26 @@ public class HttpClientFactoryResilienceTests
         _ = stub.CallCount.Should().Be(1); // a 404 HttpRequestException is not transient
     }
 
+    [Fact]
+    public async Task HttpRequestExceptionWithTransientStatus_IsRetriedThenSucceeds()
+    {
+        using StubHttpMessageHandler stub = new(
+            Throws(
+                new HttpRequestException("unavailable", null, HttpStatusCode.ServiceUnavailable)
+            ),
+            Throws(
+                new HttpRequestException("unavailable", null, HttpStatusCode.ServiceUnavailable)
+            ),
+            Status(HttpStatusCode.OK)
+        );
+        using HttpClient client = CreateStubbedClient(stub, FastOptions());
+
+        using HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/"));
+
+        _ = response.StatusCode.Should().Be(HttpStatusCode.OK);
+        _ = stub.CallCount.Should().Be(3); // 503 exception retried, then success
+    }
+
     private static HttpClientOptions FastOptions() =>
         new()
         {

--- a/UtilitiesTests/HttpClientFactoryResilienceTests.cs
+++ b/UtilitiesTests/HttpClientFactoryResilienceTests.cs
@@ -95,7 +95,7 @@ public class HttpClientFactoryResilienceTests
     }
 
     [Fact]
-    public async Task StatusBearingHttpRequestException_IsNotRetried()
+    public async Task HttpRequestExceptionWithNonTransientStatus_IsNotRetried()
     {
         using StubHttpMessageHandler stub = new(
             Throws(new HttpRequestException("not found", null, HttpStatusCode.NotFound))

--- a/UtilitiesTests/HttpClientFactoryResilienceTests.cs
+++ b/UtilitiesTests/HttpClientFactoryResilienceTests.cs
@@ -94,6 +94,21 @@ public class HttpClientFactoryResilienceTests
         _ = stub.CallCount.Should().Be(1); // programming errors are not retried
     }
 
+    [Fact]
+    public async Task StatusBearingHttpRequestException_IsNotRetried()
+    {
+        using StubHttpMessageHandler stub = new(
+            Throws(new HttpRequestException("not found", null, HttpStatusCode.NotFound))
+        );
+        using HttpClient client = CreateStubbedClient(stub, FastOptions());
+
+        _ = await FluentActions
+            .Awaiting(() => client.GetAsync(new Uri("http://localhost/")))
+            .Should()
+            .ThrowAsync<HttpRequestException>();
+        _ = stub.CallCount.Should().Be(1); // a 404 HttpRequestException is not transient
+    }
+
     private static HttpClientOptions FastOptions() =>
         new()
         {


### PR DESCRIPTION
## Summary

Refines `HttpClientFactory.IsTransientFailure` so a status-bearing `HttpRequestException` (one whose `StatusCode` is set, e.g. from `EnsureSuccessStatusCode`) is transient only for a transient status code (408/429/>= 500). A `HttpRequestException` with no status (a network/IO error) stays transient. This prevents retrying 4xx failures (400/401/404) that should fail fast.

Adds a test: a 404 `HttpRequestException` is not retried; the existing network-exception test (no status) still retries.

## Verification

- `dotnet build` - 0 warnings / 0 errors.
- `dotnet test` - resilience suite green (+1).
- `dotnet format style --verify-no-changes` clean.

Addresses a Copilot finding on the develop->main release PR (#394).

🤖 Generated with [Claude Code](https://claude.com/claude-code)