### PR TITLE
conformance: xUnit v3 migration, config hygiene, --pull=always lint tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -139,7 +139,7 @@
             "label": "Lint: EditorConfig",
             "type": "process",
             "command": "docker",
-            "args": [ "run", "--rm", "-v", "${workspaceFolder}:/check", "-w", "/check", "mstruebing/editorconfig-checker:latest" ],
+            "args": [ "run", "--rm", "--pull=always", "-v", "${workspaceFolder}:/check", "-w", "/check", "mstruebing/editorconfig-checker:latest" ],
             "problemMatcher": [],
             "presentation": {
                 "showReuseMessage": false,
@@ -150,7 +150,7 @@
             "label": "Lint: Workflows",
             "type": "process",
             "command": "docker",
-            "args": [ "run", "--rm", "-v", "${workspaceFolder}:/repo", "-w", "/repo", "rhysd/actionlint:latest", "-color" ],
+            "args": [ "run", "--rm", "--pull=always", "-v", "${workspaceFolder}:/repo", "-w", "/repo", "rhysd/actionlint:latest", "-color" ],
             "problemMatcher": [],
             "presentation": {
                 "showReuseMessage": false,
@@ -161,7 +161,7 @@
             "label": "Lint: Markdown",
             "type": "process",
             "command": "docker",
-            "args": [ "run", "--rm", "-v", "${workspaceFolder}:/workdir", "-w", "/workdir", "davidanson/markdownlint-cli2:latest", "**/*.md" ],
+            "args": [ "run", "--rm", "--pull=always", "-v", "${workspaceFolder}:/workdir", "-w", "/workdir", "davidanson/markdownlint-cli2:latest", "**/*.md" ],
             "problemMatcher": [],
             "presentation": {
                 "showReuseMessage": false,
@@ -172,7 +172,7 @@
             "label": "Lint: Spelling",
             "type": "process",
             "command": "docker",
-            "args": [ "run", "--rm", "-v", "${workspaceFolder}:/workdir", "-w", "/workdir", "ghcr.io/streetsidesoftware/cspell:latest", "--no-progress", "README.md", "HISTORY.md" ],
+            "args": [ "run", "--rm", "--pull=always", "-v", "${workspaceFolder}:/workdir", "-w", "/workdir", "ghcr.io/streetsidesoftware/cspell:latest", "--no-progress", "README.md", "HISTORY.md" ],
             "problemMatcher": [],
             "presentation": {
                 "showReuseMessage": false,

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,8 +9,8 @@
     <PackageVersion Include="Serilog" Version="4.4.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.analyzers" Version="1.27.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 </Project>

--- a/UtilitiesTests/.editorconfig
+++ b/UtilitiesTests/.editorconfig
@@ -8,6 +8,3 @@ dotnet_diagnostic.CA1707.severity = none
 
 # CA1515: xUnit discovers only public test classes, so they cannot be internal.
 dotnet_diagnostic.CA1515.severity = none
-
-# CA2007: xUnit forbids ConfigureAwait in test methods (xUnit1030), so CA2007 cannot be satisfied in test code.
-dotnet_diagnostic.CA2007.severity = none

--- a/UtilitiesTests/UtilitiesTests.csproj
+++ b/UtilitiesTests/UtilitiesTests.csproj
@@ -1,28 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Authors>Pieter Viljoen</Authors>
-    <Company>Pieter Viljoen</Company>
-    <Copyright>Pieter Viljoen</Copyright>
-    <Description>Generally useful utility classes</Description>
-    <Version>1.1.0.1</Version>
-    <FileVersion>1.1.0.1</FileVersion>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <PackageId>ptr727.Utilities.Tests</PackageId>
-    <AssemblyName>UtilitiesTests</AssemblyName>
+    <IsTestProject>true</IsTestProject>
     <RootNamespace>ptr727.Utilities.Tests</RootNamespace>
-    <NeutralLanguage>en</NeutralLanguage>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Fleet CODESTYLE conformance sweep against the LanguageTags / PlexCleaner reference repos. Three items bundled into one PR.

## Issue #380 — xUnit v3 + AwesomeAssertions, ILoggerFactory logging
**(a) Tests on xUnit v3.**
- `Directory.Packages.props`: replaced legacy `xunit` 2.9.3 with `xunit.v3` 3.2.2 (matching the fleet). The v3 toolchain packages (Microsoft.NET.Test.Sdk 18.7.0, coverlet.collector 10.0.1, xunit.analyzers 1.27.0, xunit.runner.visualstudio 3.1.5) and AwesomeAssertions 9.4.0 were already pinned.
- `UtilitiesTests/UtilitiesTests.csproj`: set `IsTestProject=true` and aligned package references to the PlexCleanerTests standard — `xunit.v3`, dropped the packaging metadata (PackageId/Version/Authors/…), SourceLink, and the now-transitive `Microsoft.Extensions.Logging.Abstractions` reference.
- The test suite already uses AwesomeAssertions `.Should()` throughout (no native `Assert.*` remained), so no assertion conversion was required.

**(b) Library logging via `ILoggerFactory`.** Already landed in an earlier commit on this branch — `Utilities.csproj` depends only on `Microsoft.Extensions.Logging.Abstractions`, `LogOptions` exposes the settable factory seam (`SetFactory`/`TrySetFactory`, defaulting to `NullLoggerFactory`), and `Sandbox` owns the concrete Serilog logger via `SerilogLoggerFactory`. Closing the issue here now that the xUnit half is complete.

## Issue #387 — project config hygiene
- **Analyzer suppressions:** removed the stale `CA2007` suppression from `UtilitiesTests/.editorconfig`; it is absent from both reference repos and the project builds warnings-clean without it under xunit.v3. The remaining suppressions were each verified still-needed by removing-and-rebuilding: `CA1707`/`CA1515` (test project) and `CA1711` (library `Ex`-suffix types) — all comment-justified.
- **Inline pragmas:** none present (`grep` for `#pragma warning` is empty).
- **GlobalUsings.cs:** present in every project (Utilities, UtilitiesTests, Sandbox).
- **Stale package source:** no GitHub Packages source exists in any `nuget.config`/`Directory.*.props`; restore is nuget.org only. Already conformant.

## Fleet `--pull=always`
`.vscode/tasks.json`: inserted `"--pull=always"` immediately after `"--rm"` in each docker Lint task (editorconfig-checker, actionlint, markdownlint-cli2, cspell) so on-demand lint always pulls the `:latest` image. JSONC and CRLF preserved.

## Validation
- `dotnet build` (warnings-as-errors): 0 warnings, 0 errors.
- `dotnet test`: 183 passed, 0 failed, 0 skipped.
- `editorconfig-checker` (docker `:latest`): clean.
- Line endings preserved per file (all edited files are CRLF; no normalization).

Closes #380
Closes #387