### PR TITLE
Remove repo-wide analyzer relaxation and honor test cancellation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -72,8 +72,8 @@ end_of_line = crlf
 # Suppressions follow CODESTYLE.md "Analyzer Diagnostics and Suppressions": prefer a
 # [SuppressMessage] attribute or the owning project's .editorconfig; relax a rule
 # repo-wide here only when it applies to every project (never a brownfield batch).
+# IDE0055: CSharpier owns formatting for every project; a second formatter would fight it.
 dotnet_diagnostic.IDE0055.severity = none
-dotnet_analyzer_diagnostic.severity = suggestion
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true

--- a/UtilitiesTests/DownloadAsyncTests.cs
+++ b/UtilitiesTests/DownloadAsyncTests.cs
@@ -9,7 +9,10 @@ public class DownloadAsyncTests
             "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png"
         );
 
-        (bool success, long size, DateTime _) = await Download.GetContentInfoAsync(uri);
+        (bool success, long size, DateTime _) = await Download.GetContentInfoAsync(
+            uri,
+            TestContext.Current.CancellationToken
+        );
 
         _ = success.Should().BeTrue();
         _ = (size > 0).Should().BeTrue();
@@ -20,7 +23,10 @@ public class DownloadAsyncTests
     {
         Uri uri = new("https://www.google.com");
 
-        (bool success, string? content) = await Download.DownloadStringAsync(uri);
+        (bool success, string? content) = await Download.DownloadStringAsync(
+            uri,
+            TestContext.Current.CancellationToken
+        );
 
         _ = success.Should().BeTrue();
         _ = content.Should().NotBeEmpty();
@@ -37,7 +43,11 @@ public class DownloadAsyncTests
 
         try
         {
-            bool result = await Download.DownloadFileAsync(uri, tempFile);
+            bool result = await Download.DownloadFileAsync(
+                uri,
+                tempFile,
+                TestContext.Current.CancellationToken
+            );
 
             _ = result.Should().BeTrue();
             _ = File.Exists(tempFile).Should().BeTrue();
@@ -57,7 +67,10 @@ public class DownloadAsyncTests
     {
         Uri invalidUri = new("https://thisdoesnotexist123456789.com/file.txt");
 
-        (bool success, long _, DateTime _) = await Download.GetContentInfoAsync(invalidUri);
+        (bool success, long _, DateTime _) = await Download.GetContentInfoAsync(
+            invalidUri,
+            TestContext.Current.CancellationToken
+        );
 
         _ = success.Should().BeFalse();
     }

--- a/UtilitiesTests/ExtensionsTests.cs
+++ b/UtilitiesTests/ExtensionsTests.cs
@@ -50,7 +50,9 @@ public class ExtensionsTests
     {
         string original = "This is a test string for async compression.";
 
-        string compressed = await original.CompressAsync();
+        string compressed = await original.CompressAsync(
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         _ = compressed.Should().NotBeNull();
         _ = compressed.Should().NotBeEmpty();
@@ -61,9 +63,13 @@ public class ExtensionsTests
     public async Task StringExtension_DecompressAsync_ShouldDecompressString()
     {
         string original = "This is a test string for async decompression.";
-        string compressed = await original.CompressAsync();
+        string compressed = await original.CompressAsync(
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
-        string decompressed = await compressed.DecompressAsync();
+        string decompressed = await compressed.DecompressAsync(
+            TestContext.Current.CancellationToken
+        );
 
         _ = decompressed.Should().Be(original);
     }
@@ -266,8 +272,12 @@ public class ExtensionsTests
 
         foreach (string original in testStrings)
         {
-            string compressed = await original.CompressAsync();
-            string decompressed = await compressed.DecompressAsync();
+            string compressed = await original.CompressAsync(
+                cancellationToken: TestContext.Current.CancellationToken
+            );
+            string decompressed = await compressed.DecompressAsync(
+                TestContext.Current.CancellationToken
+            );
 
             _ = decompressed.Should().Be(original);
         }

--- a/UtilitiesTests/FileExAsyncTests.cs
+++ b/UtilitiesTests/FileExAsyncTests.cs
@@ -9,7 +9,10 @@ public class FileExAsyncTests
 
         try
         {
-            bool result = await FileEx.DeleteFileAsync(tempFile);
+            bool result = await FileEx.DeleteFileAsync(
+                tempFile,
+                TestContext.Current.CancellationToken
+            );
 
             _ = result.Should().BeTrue();
             _ = File.Exists(tempFile).Should().BeFalse();
@@ -31,7 +34,10 @@ public class FileExAsyncTests
 
         try
         {
-            bool result = await FileEx.DeleteDirectoryAsync(tempDir);
+            bool result = await FileEx.DeleteDirectoryAsync(
+                tempDir,
+                TestContext.Current.CancellationToken
+            );
 
             _ = result.Should().BeTrue();
             _ = Directory.Exists(tempDir).Should().BeFalse();
@@ -53,11 +59,19 @@ public class FileExAsyncTests
         string subDir = Path.Combine(tempDir, "subdir");
         _ = Directory.CreateDirectory(subDir);
         string testFile = Path.Combine(subDir, "test.txt");
-        await File.WriteAllTextAsync(testFile, "test content");
+        await File.WriteAllTextAsync(
+            testFile,
+            "test content",
+            TestContext.Current.CancellationToken
+        );
 
         try
         {
-            bool result = await FileEx.DeleteDirectoryAsync(tempDir, recursive: true);
+            bool result = await FileEx.DeleteDirectoryAsync(
+                tempDir,
+                recursive: true,
+                TestContext.Current.CancellationToken
+            );
 
             _ = result.Should().BeTrue();
             _ = Directory.Exists(tempDir).Should().BeFalse();
@@ -79,7 +93,11 @@ public class FileExAsyncTests
 
         try
         {
-            bool result = await FileEx.RenameFileAsync(tempFile, newPath);
+            bool result = await FileEx.RenameFileAsync(
+                tempFile,
+                newPath,
+                TestContext.Current.CancellationToken
+            );
 
             _ = result.Should().BeTrue();
             _ = File.Exists(tempFile).Should().BeFalse();
@@ -107,7 +125,11 @@ public class FileExAsyncTests
 
         try
         {
-            bool result = await FileEx.RenameFolderAsync(tempDir, newPath);
+            bool result = await FileEx.RenameFolderAsync(
+                tempDir,
+                newPath,
+                TestContext.Current.CancellationToken
+            );
 
             _ = result.Should().BeTrue();
             _ = Directory.Exists(tempDir).Should().BeFalse();
@@ -133,9 +155,16 @@ public class FileExAsyncTests
 
         try
         {
-            await File.WriteAllTextAsync(tempFile, "test content");
+            await File.WriteAllTextAsync(
+                tempFile,
+                "test content",
+                TestContext.Current.CancellationToken
+            );
 
-            bool result = await FileEx.WaitFileReadableAsync(tempFile);
+            bool result = await FileEx.WaitFileReadableAsync(
+                tempFile,
+                TestContext.Current.CancellationToken
+            );
 
             _ = result.Should().BeTrue();
         }
@@ -156,7 +185,11 @@ public class FileExAsyncTests
 
         try
         {
-            bool result = await FileEx.CreateRandomFilledFileAsync(tempFile, fileSize);
+            bool result = await FileEx.CreateRandomFilledFileAsync(
+                tempFile,
+                fileSize,
+                TestContext.Current.CancellationToken
+            );
 
             _ = result.Should().BeTrue();
             _ = File.Exists(tempFile).Should().BeTrue();
@@ -224,11 +257,18 @@ public class FileExAsyncTests
         string tempDir = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}");
         _ = Directory.CreateDirectory(tempDir);
         string testFile = Path.Combine(tempDir, "test.txt");
-        await File.WriteAllTextAsync(testFile, "test content");
+        await File.WriteAllTextAsync(
+            testFile,
+            "test content",
+            TestContext.Current.CancellationToken
+        );
 
         try
         {
-            bool result = await FileEx.DeleteInsideDirectoryAsync(tempDir);
+            bool result = await FileEx.DeleteInsideDirectoryAsync(
+                tempDir,
+                TestContext.Current.CancellationToken
+            );
 
             _ = result.Should().BeTrue();
             _ = Directory.Exists(tempDir).Should().BeTrue(); // Directory should still exist

--- a/UtilitiesTests/HttpClientFactoryResilienceTests.cs
+++ b/UtilitiesTests/HttpClientFactoryResilienceTests.cs
@@ -14,7 +14,10 @@ public class HttpClientFactoryResilienceTests
         );
         using HttpClient client = CreateStubbedClient(stub, FastOptions());
 
-        using HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/"));
+        using HttpResponseMessage response = await client.GetAsync(
+            new Uri("http://localhost/"),
+            TestContext.Current.CancellationToken
+        );
 
         _ = response.StatusCode.Should().Be(HttpStatusCode.OK);
         _ = stub.CallCount.Should().Be(3); // initial attempt + 2 retries
@@ -26,7 +29,10 @@ public class HttpClientFactoryResilienceTests
         using StubHttpMessageHandler stub = new(Status(HttpStatusCode.NotFound));
         using HttpClient client = CreateStubbedClient(stub, FastOptions());
 
-        using HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/"));
+        using HttpResponseMessage response = await client.GetAsync(
+            new Uri("http://localhost/"),
+            TestContext.Current.CancellationToken
+        );
 
         _ = response.StatusCode.Should().Be(HttpStatusCode.NotFound);
         _ = stub.CallCount.Should().Be(1); // 404 is not transient
@@ -123,7 +129,10 @@ public class HttpClientFactoryResilienceTests
         );
         using HttpClient client = CreateStubbedClient(stub, FastOptions());
 
-        using HttpResponseMessage response = await client.GetAsync(new Uri("http://localhost/"));
+        using HttpResponseMessage response = await client.GetAsync(
+            new Uri("http://localhost/"),
+            TestContext.Current.CancellationToken
+        );
 
         _ = response.StatusCode.Should().Be(HttpStatusCode.OK);
         _ = stub.CallCount.Should().Be(3); // 503 exception retried, then success

--- a/UtilitiesTests/StringCompressionAsyncTests.cs
+++ b/UtilitiesTests/StringCompressionAsyncTests.cs
@@ -14,10 +14,14 @@ public class StringCompressionAsyncTests
         string text = Convert.ToBase64String(buffer);
 
         // Compress the string asynchronously
-        string compressed = await text.CompressAsync();
+        string compressed = await text.CompressAsync(
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         // Decompress asynchronously
-        string decompressed = await compressed.DecompressAsync();
+        string decompressed = await compressed.DecompressAsync(
+            TestContext.Current.CancellationToken
+        );
 
         // Compare to original string
         _ = decompressed.Should().Be(text);
@@ -32,8 +36,10 @@ public class StringCompressionAsyncTests
         string text =
             "This is a test string that will be compressed with different compression levels.";
 
-        string compressed = await text.CompressAsync(level);
-        string decompressed = await compressed.DecompressAsync();
+        string compressed = await text.CompressAsync(level, TestContext.Current.CancellationToken);
+        string decompressed = await compressed.DecompressAsync(
+            TestContext.Current.CancellationToken
+        );
 
         _ = decompressed.Should().Be(text);
     }
@@ -91,8 +97,12 @@ public class StringCompressionAsyncTests
         // Create a large repetitive string (should compress well)
         string largeText = new('A', 1024 * 1024); // 1MB of 'A's
 
-        string compressed = await largeText.CompressAsync();
-        string decompressed = await compressed.DecompressAsync();
+        string compressed = await largeText.CompressAsync(
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+        string decompressed = await compressed.DecompressAsync(
+            TestContext.Current.CancellationToken
+        );
 
         _ = decompressed.Should().Be(largeText);
         _ = (compressed.Length < largeText.Length)


### PR DESCRIPTION
Follow-up to the conformance audit for #387 (finding 1, analyzer suppression hygiene).

## What prompted this

[CODESTYLE.md](../blob/develop/CODESTYLE.md) "Analyzer Suppressions" names `dotnet_analyzer_diagnostic.severity` as the exact anti-pattern it forbids -- relaxing a batch of rules repo-wide -- yet the root `.editorconfig` carried it.

## What removing it surfaced

Exactly one rule, and none of it in shipping code:

| Rule | Sites | Project |
| --- | --- | --- |
| xUnit1051 | 29 | UtilitiesTests |

`Utilities` and `Sandbox` produced **zero** findings under `AnalysisLevel=latest-all` + `AnalysisMode=All`. I re-ran with `-p:EnforceCodeStyleInBuild=true` to confirm IDE analyzers were not being silently skipped -- same result. The relaxation was hiding nothing in library code.

xUnit1051 is a true positive, not a suppression candidate: it asks that async calls in tests pass `TestContext.Current.CancellationToken` so xUnit v3 can cancel a stalled test. The clearest case is `DownloadAsyncTests`, which makes real network calls and previously had no cancellation path if a request hung.

## Audit of every other suppression

Each was removed and rebuilt independently to prove it is load-bearing. All of them are -- kept, no changes:

| Suppression | Scope | Fires when removed | Verdict |
| --- | --- | --- | --- |
| `CA1711` | Utilities | yes | Deliberate `Ex` suffix convention |
| `CA1707` | UtilitiesTests | yes | xUnit `Method_Scenario_Expected` naming |
| `CA1515` | UtilitiesTests | yes | xUnit needs public test classes |
| `NoWarn IL3058` | Utilities, Sandbox | yes (10 under `PublishAot=true`) | Polly/Serilog not annotated AOT-compatible; no source location to scope |
| `IDE0055` | root | no | Inert today, but CSharpier owns formatting; kept as a guard, now with a rationale comment |

The naming-rule severities were also raised to `warning` as a probe and produced nothing.

## Verification

- `dotnet build -c Release` with `TreatWarningsAsErrors` intact: 0 warnings, 0 errors
- `dotnet test -c Release`: 183/183 passed
- `dotnet format style --verify-no-changes`: clean
- CSharpier + `dotnet format` Husky hooks passed on commit

## Notes

No `Closes #387` here -- per [AGENTS.md](../blob/develop/AGENTS.md) "Branching Model", closing keywords belong in the `develop -> main` promotion PR. #387's other three findings (inline pragmas, `GlobalUsings.cs`, stale package source) were already resolved in earlier work and need no change.

A fleet-wide issue is being filed against ProjectTemplate, since LanguageTags carries the identical `dotnet_analyzer_diagnostic` line and the other repos have not been probed.