### PR TITLE
Add Codecov coverage shield to the README build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Some useful and not so useful C# .NET utility classes.
 ### Build Status
 
 [![Release Status][releasebuildstatus-shield]][actions-link]\
-[![Last Commit][lastcommit-shield]][commits-link]
+[![Last Commit][lastcommit-shield]][commits-link]\
+[![Coverage][coverage-shield]][coverage-link]
 
 ### Releases
 
@@ -69,6 +70,8 @@ Licensed under the [MIT License][license-link]\
 
 [actions-link]: https://github.com/ptr727/Utilities/actions
 [commits-link]: https://github.com/ptr727/Utilities/commits/main
+[coverage-link]: https://app.codecov.io/gh/ptr727/Utilities
+[coverage-shield]: https://img.shields.io/codecov/c/github/ptr727/Utilities?logo=codecov&label=Coverage
 [github-link]: https://github.com/ptr727/Utilities
 [lastcommit-shield]: https://img.shields.io/github/last-commit/ptr727/Utilities?logo=github&label=Last%20Commit
 [license-link]: ./LICENSE


### PR DESCRIPTION
Coverage has been uploaded to Codecov since the coverage workflow landed (#377), but the README never surfaced it.

Adds a Coverage shield to the **Build Status** block, following the badge pattern used in [aiopurpleair](https://github.com/ptr727/aiopurpleair):

```markdown
[![Release Status][releasebuildstatus-shield]][actions-link]\
[![Last Commit][lastcommit-shield]][commits-link]\
[![Coverage][coverage-shield]][coverage-link]
```

Shield and link definitions were inserted in the file's existing alphabetical order, between `commits-link` and `github-link`.

## Verification

- Shield URL returns HTTP 200 and renders real data (`coverage: 67%`), not `unknown`
- markdownlint MD052 (undefined reference) clean -- both definitions resolve
- CRLF preserved
- No `cspell.json` change needed: `codecov` is not flagged (aiopurpleair carries the same badge with no dictionary entry), and README is in the CI spell-check scope per CODESTYLE