### PR TITLE
Describe the 5D audit as reporting defects, not failing

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -590,8 +590,9 @@ Follow the read-only audit in [`AUDIT.md`](./AUDIT.md) (section 6). It confirms 
 the `main`/`develop` rulesets enforce the required merge method + status check + signed commits +
 strict-off, and the repository settings (auto-merge, allowed merge methods) are in place, reporting any
 drift. A missing or incorrect configuration item is a defect (D10). Secret *values* cannot be read
-back, so the audit asserts the names exist (failing if it cannot query them); the GitHub App installation is a
-best-effort check (a precise check needs app-level auth, so it notes rather than fails). The NuGet.org trusted-publishing
+back, so the audit checks that the names exist, reporting a missing name or a failed query as a defect; the
+GitHub App installation is a best-effort check (a precise check needs app-level auth, so it notes rather
+than reports a defect). The NuGet.org trusted-publishing
 policy (D4.7) lives outside GitHub and cannot be checked by `gh api`, so it sits outside AUDIT.md's drift
 report entirely - it is a manual checklist item, verified on NuGet.org (see section 6).
 
@@ -664,5 +665,5 @@ baseline and reports drift without changing anything; that procedure **is** the 
 `repo-config/configure.sh [owner/repo] [release|operational]` applies the baseline to a repo (idempotent;
 both arguments optional - the repo defaults to the current one, and the model to the registry lookup,
 falling back to `release` with a warning when no registry is present).
-Secret values cannot be read back, so the audit asserts the names exist (failing if they cannot be queried);
-the App installation is a best-effort check.
+Secret values cannot be read back, so the audit checks that the names exist, reporting a missing name or a
+failed query as a defect; the App installation is a best-effort check.


### PR DESCRIPTION
Follow-up to #422, from Copilot review on the promotion PR #423.

`AUDIT.md` is explicitly read-only: its secrets check is

```sh
grep -qx "$s" <<<"$names" && echo "$store/$s: present" || echo "$store/$s: MISSING (defect)"
```

-- `echo`-based, with no defined non-zero exit contract. But two `WORKFLOW.md` sentences still said the audit "asserts" the names exist and "fail[s] if it cannot query them". That wording is a leftover from when `configure.sh check` performed the audit and exited non-zero on drift; #422 moved the audit to AUDIT.md but left these two clauses describing the old behavior.

Both now describe what AUDIT.md actually does: check the names, and report a missing name or a failed query as a defect. The App-installation sentence was adjusted for the same reason ("notes rather than fails" -> "notes rather than reports a defect").

Docs-only; no shipped input, so no release impact.