### PR TITLE
Spell out the up-to-date ruleset setting in the 5D audit summary

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -587,9 +587,9 @@ determined by NBGV from the checkout state in section 3.*
 ### 5D. Configuration audit
 
 Follow the read-only audit in [`AUDIT.md`](./AUDIT.md) (section 6). It confirms the listed secrets exist,
-the `main`/`develop` rulesets enforce the required merge method + status check + signed commits +
-strict-off, and the repository settings (auto-merge, allowed merge methods) are in place, reporting any
-drift. A missing or incorrect configuration item is a defect (D10). Secret *values* cannot be read
+the `main`/`develop` rulesets enforce the required merge method + status check + signed commits + "require
+branches up to date before merging" **off**, and the repository settings (auto-merge, allowed merge
+methods) are in place, reporting any drift. A missing or incorrect configuration item is a defect (D10). Secret *values* cannot be read
 back, so the audit checks that the names exist, reporting a missing name or a failed query as a defect; the
 GitHub App installation is a best-effort check (a precise check needs app-level auth, so it notes rather
 than reports a defect). The NuGet.org trusted-publishing

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -587,14 +587,14 @@ determined by NBGV from the checkout state in section 3.*
 ### 5D. Configuration audit
 
 Follow the read-only audit in [`AUDIT.md`](./AUDIT.md) (section 6). It confirms the listed secrets exist,
-the `main`/`develop` rulesets enforce the required merge method + status check + signed commits + "require
-branches up to date before merging" **off**, and the repository settings (auto-merge, allowed merge
-methods) are in place, reporting any drift. A missing or incorrect configuration item is a defect (D10). Secret *values* cannot be read
-back, so the audit checks that the names exist, reporting a missing name or a failed query as a defect; the
-GitHub App installation is a best-effort check (a precise check needs app-level auth, so it notes rather
-than reports a defect). The NuGet.org trusted-publishing
-policy (D4.7) lives outside GitHub and cannot be checked by `gh api`, so it sits outside AUDIT.md's drift
-report entirely - it is a manual checklist item, verified on NuGet.org (see section 6).
+the `main`/`develop` rulesets enforce the required merge method + status check + signed commits, with
+"require branches up to date before merging" **off**, and the repository settings (auto-merge, allowed
+merge methods) are in place, reporting any drift. A missing or incorrect configuration item is a defect
+(D10). Secret *values* cannot be read back, so the audit checks that the names exist, reporting a missing
+name or a failed query as a defect; the GitHub App installation is a best-effort check (a precise check
+needs app-level auth, so it notes rather than reports a defect). The NuGet.org trusted-publishing policy
+(D4.7) lives outside GitHub and cannot be checked by `gh api`, so it sits outside AUDIT.md's drift report
+entirely - it is a manual checklist item, verified on NuGet.org (see section 6).
 
 ### Assessment
 


### PR DESCRIPTION
Closes the terminology nit Copilot raised on #423, which I deferred there as out of scope for that promotion.

`strict-off` appeared exactly once in `WORKFLOW.md` (the 5D audit summary). Section 6 spells the same setting out twice:

- `main`: `"require branches up to date before merging" is **off**`
- `develop`: `"up to date" is **off**`

The summary now uses the section 6 phrasing, so both places name the setting identically.

The word "strict" survives at line 646 (`so the strict check would fail every release`), which is correct -- that sentence is explaining *why* the setting is off, and "the strict check" is GitHub's own term for the behavior.

Docs-only; no shipped input, so no release impact.