### PR TITLE
Promote develop to main

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -587,14 +587,14 @@ determined by NBGV from the checkout state in section 3.*
 ### 5D. Configuration audit
 
 Follow the read-only audit in [`AUDIT.md`](./AUDIT.md) (section 6). It confirms the listed secrets exist,
-the `main`/`develop` rulesets enforce the required merge method + status check + signed commits +
-strict-off, and the repository settings (auto-merge, allowed merge methods) are in place, reporting any
-drift. A missing or incorrect configuration item is a defect (D10). Secret *values* cannot be read
-back, so the audit checks that the names exist, reporting a missing name or a failed query as a defect; the
-GitHub App installation is a best-effort check (a precise check needs app-level auth, so it notes rather
-than reports a defect). The NuGet.org trusted-publishing
-policy (D4.7) lives outside GitHub and cannot be checked by `gh api`, so it sits outside AUDIT.md's drift
-report entirely - it is a manual checklist item, verified on NuGet.org (see section 6).
+the `main`/`develop` rulesets enforce the required merge method + status check + signed commits, with
+"require branches up to date before merging" **off**, and the repository settings (auto-merge, allowed
+merge methods) are in place, reporting any drift. A missing or incorrect configuration item is a defect
+(D10). Secret *values* cannot be read back, so the audit checks that the names exist, reporting a missing
+name or a failed query as a defect; the GitHub App installation is a best-effort check (a precise check
+needs app-level auth, so it notes rather than reports a defect). The NuGet.org trusted-publishing policy
+(D4.7) lives outside GitHub and cannot be checked by `gh api`, so it sits outside AUDIT.md's drift report
+entirely - it is a manual checklist item, verified on NuGet.org (see section 6).
 
 ### Assessment
 


### PR DESCRIPTION
Promotion of #425 to `main`.

## Contents

| PR | Change |
| --- | --- |
| #425 | Spell out the up-to-date ruleset setting in the 5D audit summary |

Replaces the one-off `strict-off` term with section 6's phrasing (`"require branches up to date before merging"` **off**), so the audit summary and the ruleset description name the setting identically. Review also caught that the first attempt split the quoted label across a line break, making it unsearchable -- fixed, and the paragraph reflowed to the file's ~105-character width after earlier edits had left a 142-character line.

This closes out the terminology finding Copilot raised on #423, which was deferred there as out of scope for that promotion.

## Release impact: no auto-publish

Docs-only. No shipped input touched, so no stable release fires. NuGet stays at 4.0.18.